### PR TITLE
feature: respect kbin style options

### DIFF
--- a/mods/label.user.js
+++ b/mods/label.user.js
@@ -8,17 +8,25 @@
 // @license      MIT
 // ==/UserScript==
 
-function labelOp(toggle){
-    if (toggle) {
-	let settings = getModSettings("labelcolors")
-	let fg = settings["fgcolor"]
-	let bg = settings["bgcolor"]
-        document.styleSheets[0].addRule('.author > header > .user-inline::after','content: " OP";color:' +
-		fg +
-		';background-color:' +
-		bg +
-		';margin-left: 3px;padding-left: 1px;padding-right: 5px');
-    } else {
-         document.styleSheets[0].addRule('.author > header > .user-inline::after','content: "";background-color:unset;padding-left: 0px !important');
-    }
+function labelOp(toggle) {
+	if (toggle) {
+		let settings = getModSettings("labelcolors");
+		let fg = settings["fgcolor"];
+		let bg = settings["bgcolor"];
+		safeGM('addStyle', `
+            blockquote.author a.user-inline::after {
+                content: 'OP';
+                font-weight: bold;
+                color: ${fg};
+                background-color: ${bg};
+                margin-left: 4px;
+                padding: 0px 5px 0px 5px;
+            }
+            body.rounded-edges blockquote.author a.user-inline::after {
+                border-radius: var(--kbin-rounded-edges-radius);
+            }
+        `);
+	} else {
+		safeGM('addStyle', 'blockquote.author a.user-inline::after { content: ""; background-color: unset; padding: unset; margin-left: unset; }');
+	}
 }


### PR DESCRIPTION
Will now respect kbin style selection (i.e., square or rounded borders). Code refactor and change to support safeGM because why not?