### PR TITLE
Prevent OP label from showing on children of OP when collapsible comments is enabled

### DIFF
--- a/mods/label.user.js
+++ b/mods/label.user.js
@@ -4,7 +4,7 @@ function labelOp (toggle) {
         let fg = settings["fgcolor"];
         let bg = settings["bgcolor"];
         safeGM('addStyle', `
-            blockquote.author a.user-inline::after {
+            blockquote.author > header > a.user-inline::after {
                 content: 'OP';
                 font-weight: bold;
                 color: ${fg};


### PR DESCRIPTION
I made the CSS selector a bit stricter to prevent it from applying the tag to replies to OP's comments