### PR TITLE
[Mod] Fix code blocks

### DIFF
--- a/mods/fix-codeblocks/fix-codeblocks.json
+++ b/mods/fix-codeblocks/fix-codeblocks.json
@@ -7,5 +7,5 @@
   "login": false,
   "recurs": true,
   "entrypoint": "fixLemmyCodeblocks",
-  "page": "General"
+  "page": "general"
 }

--- a/mods/fix-codeblocks/fix-codeblocks.json
+++ b/mods/fix-codeblocks/fix-codeblocks.json
@@ -1,0 +1,11 @@
+{
+  "name": "Fix Lemmy Code Blocks",
+  "author": "Pamasich",
+  "version": "1.0.0",
+  "label": "Repair Lemmy code blocks",
+  "desc": "Lemmy federates special <span> HTML tags on each line of its code blocks which /kbin displays in plaintext, resulting in code blocks being hard to read. This mod removes those tags.",
+  "login": false,
+  "recurs": true,
+  "entrypoint": "fixLemmyCodeblocks",
+  "page": "General"
+}

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -1,0 +1,37 @@
+function fixLemmyCodeblocks (toggle) {
+    // included everything inside here because of the private functions advisory
+
+    const testPattern = /\n?<span style="color:#323232;">(.+\n)+<\/span>\n?/;
+    const startTagPattern = /^\n?<span style="color:#323232;">/;
+    const endTagPattern = /\n<\/span>\n?$/;
+    const combinedPattern = /^<\/span><span style="color:#323232;">/gm;
+    // matches any line (or rather the start thereof) except the first one
+    const startOfNewLinePattern = /(?<=\n)^/gm;
+
+    const attribute = "data-code-fixed";
+    const startTag = '<span style="color:#323232;">';
+    const endTag = "</span>";
+
+    function fixCodeblock (code) {
+        if (testPattern.test(code.innerText)) {
+            code.innerText = code.innerText
+                .replace(startTagPattern, "")
+                .replaceAll(combinedPattern, "")
+                .replace(endTagPattern, "");
+            code.setAttribute(attribute, "");
+        }
+    }
+
+    // including this to keep the mod's behavior consistent with the others
+    function revertCodeblock (code) {
+        const text = code.innerText.replaceAll(startOfNewLinePattern, `${endTag}${startTag}`);
+        code.innerText = `\n${startTag}${text}\n${endTag}\n`;
+        code.removeAttribute(attribute);
+    }
+
+    if (toggle) {
+        document.querySelectorAll("pre code").forEach(fixCodeblock);
+    } else {
+        document.querySelectorAll(`pre code[${attribute}]`).forEach(revertCodeblock);
+    }
+}


### PR DESCRIPTION
## What's added

Added a mod that fixes a long-running issue with code blocks federated from Lemmy on /kbin. 

Lemmy includes extra `<span style="color:#323232;">` tags enclosing every line in their federated code blocks which /kbin just displays in plaintext. See [this comment](https://kbin.social/m/programming@programming.dev/t/623282/Implementing-Tic-Tac-Toe-with-170mb-of-HTML-no-JS#entry-comment-3548488) for an example.

![image](https://github.com/aclist/kbin-kes/assets/18553452/b11201ba-0681-4ce5-8c63-f5eae5071dde)

This mod fixes that by removing those tags:

![image](https://github.com/aclist/kbin-kes/assets/18553452/042f74bc-5668-4f7b-8c51-f68387c77300)

## Checklist

Before submission, verify that you checked the below. If complete, tick the box.

- [x] The PR does not modify `kes.user.js`. (This file is autogenerated)
- [ ] `manifest.json` was updated to include the add-on's metadata
- [x] If calling GM functions, [safeGM](https://aclist.github.io/kes/kes.html#_compatibility_api) was used
- [x] If the add-on recurs when contents update, it does not call its own mutation observers (this is handled by KES)
- [x] The add-on has a clearly defined entry point function, and this function is listed by name in the manifest
- [x] Some explicit toggle logic handles both TRUE and FALSE states (setup and teardown)

I'm a bit confused by manifest.json being in this mod-specific checklist, you might want to edit either the checklist or the documentation. The latter claims manifest.json is automated and I should only be submitting the mod's folder and no other files, so I'm leaving manifest.json alone unless you confirm I should change something about it.