### PR TITLE
(fix-codeblocks) Fixes in response to #237

### DIFF
--- a/mods/fix-codeblocks/fix-codeblocks.json
+++ b/mods/fix-codeblocks/fix-codeblocks.json
@@ -1,7 +1,7 @@
 {
   "name": "Fix Lemmy Code Blocks",
   "author": "Pamasich",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "label": "Repair Lemmy code blocks",
   "desc": "Lemmy federates special <span> HTML tags on each line of its code blocks which /kbin displays in plaintext, resulting in code blocks being hard to read. This mod removes those tags.",
   "login": false,

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -1,8 +1,10 @@
 function fixLemmyCodeblocks (toggle) {
-    const testPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">(.+\n)+<\/span>\n?$/;
-    const startTagPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">/;
-    const endTagPattern = /\n<\/span>\n?$/;
-    const combinedPattern = /<\/span><span style="color:#[0-9a-fA-F]{6};">/g;
+    const stylePattern = "((font-style:italic|font-weight:bold);)?color:#[0-9a-fA-F]{6};";
+
+    const testPattern = new RegExp(`^\\n?<span style="${stylePattern}">(.+\\n)+<\\/span>\\n?$`);
+    const startTagPattern = new RegExp(`^\\n?<span style="${stylePattern}">`);
+    const endTagPattern = new RegExp(`\\n<\\/span>\\n?$`);
+    const combinedPattern = new RegExp(`<\\/span><span style="${stylePattern}">`, "g");
 
     const fixedCodeAttribute = "data-fixed-code"
 

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -3,33 +3,36 @@ function fixLemmyCodeblocks (toggle) {
     const startTagPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">/;
     const endTagPattern = /\n<\/span>\n?$/;
     const combinedPattern = /^<\/span><span style="color:#[0-9a-fA-F]{6};">/gm;
-    // matches any line (or rather the start thereof) except the first one
-    const startOfNewLinePattern = /(?<=\n)^/gm;
 
-    const attribute = "data-code-fixed";
-    const startTag = '<span style="color:#323232;">';
-    const endTag = "</span>";
+    const fixedCodeAttribute = "data-fixed-code"
 
-    function fixCodeblock (code) {
-        if (testPattern.test(code.innerText)) {
-            code.innerText = code.innerText
-                .replace(startTagPattern, "")
-                .replaceAll(combinedPattern, "")
-                .replace(endTagPattern, "");
-            code.setAttribute(attribute, "");
-        }
+    /** @param {HTMLElement} codeblock */
+    function fixCodeblock (codeblock) {
+        if (!testPattern.test(codeblock.innerText)) return;
+
+        const fixedBlock = document.createElement("code");
+        fixedBlock.setAttribute(fixedCodeAttribute, "");
+        codeblock.parentNode.insertBefore(fixedBlock, codeblock.nextSibling);
+
+        fixedBlock.innerText = codeblock.innerText
+            .replace(startTagPattern, "")
+            .replace(combinedPattern, "")
+            .replace(endTagPattern, "");
+
+        codeblock.style.display = "none";
     }
 
-    // including this to keep the mod's behavior consistent with the others
-    function revertCodeblock (code) {
-        const text = code.innerText.replaceAll(startOfNewLinePattern, `${endTag}${startTag}`);
-        code.innerText = `\n${startTag}${text}\n${endTag}\n`;
-        code.removeAttribute(attribute);
+    /** @param {HTMLElement} fixedBlock */
+    function revertCodeblock (fixedBlock) {
+        /** @type {HTMLElement} */
+        const originalBlock = fixedBlock.previousElementSibling;
+        originalBlock.style.removeProperty("display");
+        fixedBlock.parentNode.removeChild(fixedBlock);
     }
 
     if (toggle) {
         document.querySelectorAll("pre code").forEach(fixCodeblock);
     } else {
-        document.querySelectorAll(`pre code[${attribute}]`).forEach(revertCodeblock);
+        document.querySelectorAll(`pre code[${fixedCodeAttribute}]`).forEach(revertCodeblock);
     }
 }

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -1,7 +1,5 @@
 function fixLemmyCodeblocks (toggle) {
-    // included everything inside here because of the private functions advisory
-
-    const testPattern = /\n?<span style="color:#323232;">(.+\n)+<\/span>\n?/;
+    const testPattern = /^\n?<span style="color:#323232;">(.+\n)+<\/span>\n?$/;
     const startTagPattern = /^\n?<span style="color:#323232;">/;
     const endTagPattern = /\n<\/span>\n?$/;
     const combinedPattern = /^<\/span><span style="color:#323232;">/gm;

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -9,6 +9,7 @@ function fixLemmyCodeblocks (toggle) {
     /** @param {HTMLElement} codeblock */
     function fixCodeblock (codeblock) {
         if (!testPattern.test(codeblock.innerText)) return;
+        if (codeblock.nextElementSibling?.hasAttribute(fixedCodeAttribute)) return;
 
         const fixedBlock = document.createElement("code");
         fixedBlock.setAttribute(fixedCodeAttribute, "");

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -2,7 +2,7 @@ function fixLemmyCodeblocks (toggle) {
     const testPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">(.+\n)+<\/span>\n?$/;
     const startTagPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">/;
     const endTagPattern = /\n<\/span>\n?$/;
-    const combinedPattern = /^<\/span><span style="color:#[0-9a-fA-F]{6};">/gm;
+    const combinedPattern = /<\/span><span style="color:#[0-9a-fA-F]{6};">/g;
 
     const fixedCodeAttribute = "data-fixed-code"
 
@@ -16,7 +16,7 @@ function fixLemmyCodeblocks (toggle) {
 
         fixedBlock.innerText = codeblock.innerText
             .replace(startTagPattern, "")
-            .replace(combinedPattern, "")
+            .replaceAll(combinedPattern, "")
             .replace(endTagPattern, "");
 
         codeblock.style.display = "none";

--- a/mods/fix-codeblocks/fix-codeblocks.user.js
+++ b/mods/fix-codeblocks/fix-codeblocks.user.js
@@ -1,8 +1,8 @@
 function fixLemmyCodeblocks (toggle) {
-    const testPattern = /^\n?<span style="color:#323232;">(.+\n)+<\/span>\n?$/;
-    const startTagPattern = /^\n?<span style="color:#323232;">/;
+    const testPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">(.+\n)+<\/span>\n?$/;
+    const startTagPattern = /^\n?<span style="color:#[0-9a-fA-F]{6};">/;
     const endTagPattern = /\n<\/span>\n?$/;
-    const combinedPattern = /^<\/span><span style="color:#323232;">/gm;
+    const combinedPattern = /^<\/span><span style="color:#[0-9a-fA-F]{6};">/gm;
     // matches any line (or rather the start thereof) except the first one
     const startOfNewLinePattern = /(?<=\n)^/gm;
 


### PR DESCRIPTION
[example]: https://kbin.social/m/programming@programming.dev/t/726929/The-C-scope-resolution-operator-is-beautiful

This pull request resolves the issues seen in #237.

With these changes, the [example] brought up there works perfectly.

Specifically, the two issues that were made apparent in the [example] are
1. the mod determines erroneous tags by a specific color, but they can have any color.
2. the mod assumes there's one erroneous closing and one ending tag per line only, but there can be any number of them.

To make sure these can be restored correctly on teardown, the mod now preserves the original code and merely hides it, instead adding the fixed code to a new element. On teardown the new element is then simply deleted and the original one made visible again.

I've also fixed an issue with the overall test the mod makes first to determine if a code block needs to be fixed. It's supposed to match the entire code, but was returning true if only a part of it matched. Which is why the example added tags that never existed on teardown for OP, it should have never recognized that code block in the first place if it worked correctly.