### PR TITLE
[Mod] Unsanitize CSS (another kbin bugfix)

### DIFF
--- a/mods/unsanitize_css/unsanitize_css.json
+++ b/mods/unsanitize_css/unsanitize_css.json
@@ -1,0 +1,13 @@
+{
+    "name": "Magazine CSS Fix — Unsanitize",
+    "namespace": "unsanitize-css",
+    "author": "Pamasich",
+    "version": "1.0.0",
+    "label": "Unsanitize Magazine CSS",
+    "desc": "Kbin supports custom CSS for magazines, but that functionality is limited because kbin wrongly replaces some important CSS characters with HTML escape codes, making the code partially non-functional. This addon fixes the issue by undoing those replacements, making the CSS actually work as expected.\n\nIt's unclear if this addon is needed on mbin, but it won't cause any issues if enabled.",
+    "login": false,
+    "recurs": false,
+    "entrypoint": "unsanitize_css",
+    "page": "general"
+  }
+  

--- a/mods/unsanitize_css/unsanitize_css.json
+++ b/mods/unsanitize_css/unsanitize_css.json
@@ -4,7 +4,7 @@
     "author": "Pamasich",
     "version": "1.0.0",
     "label": "Unsanitize Magazine CSS",
-    "desc": "Kbin supports custom CSS for magazines, but that functionality is limited because kbin wrongly replaces some important CSS characters with HTML escape codes, making the code partially non-functional. This addon fixes the issue by undoing those replacements, making the CSS actually work as expected.\n\nIt's unclear if this addon is needed on mbin, but it won't cause any issues if enabled.",
+    "desc": "Kbin supports custom CSS for magazines, but that functionality is limited because kbin wrongly replaces some important CSS characters with HTML escape codes, making the code partially non-functional. This addon fixes the issue by undoing those replacements, making the CSS actually work as expected.\n\nThis mod is unnecessary on mbin.",
     "login": false,
     "recurs": false,
     "entrypoint": "unsanitize_css",

--- a/mods/unsanitize_css/unsanitize_css.user.js
+++ b/mods/unsanitize_css/unsanitize_css.user.js
@@ -1,0 +1,56 @@
+/**
+ * Kbin currently wrongly sanitizes its custom CSS (as defined by magazines and users),
+ * causing some characters to be replaced by HTML escape codes. This breaks CSS rules involving,
+ * for example, the direct descendant selector (>) or nested CSS using the & character.
+ * 
+ * This mod aims to fix that issue until kbin does.
+ * 
+ * @todo Check whether this is *needed* on mbin, which will require creating a magazine with
+ * custom css there. It's not a priority though as long as the mod doesn't cause issues on mbin.
+ * 
+ * @param {Boolean} isActive Whether the mod has been turned on
+ */
+function fixWronglySanitizedCss (isActive) { // eslint-disable-line no-unused-vars
+    if (isActive) {
+        setup();
+    } else {
+        teardown();
+    }
+
+    function setup () {
+        var dummy = document.createElement("div");
+        document.querySelectorAll("style:not([id])").forEach((style) => {
+            dummy.innerHTML = style.textContent;
+            if (dummy.innerHTML != dummy.textContent) {
+                style.textContent = dummy.textContent;
+                markAsUnsanitized(style);
+            }
+        });
+        dummy.remove();
+    }
+
+    function teardown () {
+        var dummy = document.createElement("div");
+        Array.of(document.querySelectorAll("style:not([id])"))
+            .filter((style) => isUnsanitized(style))
+            .forEach((style) => {
+                dummy.textContent = style.textContent;
+                style.textContent = dummy.innerHTML;
+                markAsSanitized(style);
+            });
+        dummy.remove();
+    }
+
+    /** @param {HTMLElement} elem @returns {Boolean} */
+    function isUnsanitized (elem) {
+        return elem.dataset?.unsanitized;
+    } 
+    /** @param {HTMLElement} elem */
+    function markAsUnsanitized (elem) {
+        elem.dataset.unsanitized = true;
+    }
+    /** @param {HTMLElement} elem */
+    function markAsSanitized (elem) {
+        delete elem.dataset.unsanitized;
+    }
+}

--- a/mods/unsanitize_css/unsanitize_css.user.js
+++ b/mods/unsanitize_css/unsanitize_css.user.js
@@ -5,9 +5,6 @@
  * 
  * This mod aims to fix that issue until kbin does.
  * 
- * @todo Check whether this is *needed* on mbin, which will require creating a magazine with
- * custom css there. It's not a priority though as long as the mod doesn't cause issues on mbin.
- * 
  * @param {Boolean} isActive Whether the mod has been turned on
  */
 function fixWronglySanitizedCss (isActive) { // eslint-disable-line no-unused-vars
@@ -31,7 +28,7 @@ function fixWronglySanitizedCss (isActive) { // eslint-disable-line no-unused-va
 
     function teardown () {
         var dummy = document.createElement("div");
-        Array.of(document.querySelectorAll("style:not([id])"))
+        Array.from(document.querySelectorAll("style:not([id])"))
             .filter((style) => isUnsanitized(style))
             .forEach((style) => {
                 dummy.textContent = style.textContent;
@@ -43,7 +40,7 @@ function fixWronglySanitizedCss (isActive) { // eslint-disable-line no-unused-va
 
     /** @param {HTMLElement} elem @returns {Boolean} */
     function isUnsanitized (elem) {
-        return elem.dataset?.unsanitized;
+        return elem.dataset.unsanitized;
     } 
     /** @param {HTMLElement} elem */
     function markAsUnsanitized (elem) {


### PR DESCRIPTION
Kbin currently allows magazines to declare custom CSS that is applied while viewing them, and users can also change the CSS of the site in their settings.

This behavior is currently bugged however. Any CSS defined this way gets HTML escaped, causing certain characters like > and & to be replaced with HTML escape codes. This causes any CSS rule that uses them to not actually work, causing confusion and imposing unnecessary limitations on what can be achieved.

Until kbin fixes this bug themselves, I've implemented this fix as a mod.

I doubt this has a lot of use on its own currently, especially with how underused CSS is on kbin in the first place. And anyone who tests their code wouldn't have CSS that needs this mod running on their magazine anyway. For user CSS, I recommend userstyles over kbin's builtin functionality anyway.
This is very much a "just in case" mod with the reason I'm implementing it now being to act as a dependency (so a use case for the discussed depends_on, once that's implemented) for another bugfix mod which needs to know which style tag contains the magazine CSS.

Add-ons (mods):
- [x] A directory containing the add-on's JS code and a standalone JSON manifest containing metadata, both prefixed with the same name, was included
- [x] The PR does not modify KES files other than those within its own directory.
- [x] If calling GM functions, [safeGM](https://aclist.github.io/kes/kes.html#_compatibility_api) was used
- [x] If the add-on recurs when contents update, it does not call its own mutation observers (this is handled by KES)
- [x] The add-on has a clearly defined entry point function, and this function is listed by name in the manifest
- [x] Some explicit toggle logic handles both TRUE and FALSE states (setup and teardown) and reverts the page to its prior state
