### PR TITLE
[MOD] Helpful missing user/magazine page

### DIFF
--- a/mods/missing_actor_info/missing_actor_info.json
+++ b/mods/missing_actor_info/missing_actor_info.json
@@ -1,0 +1,11 @@
+{
+    "name": "Helpful overhaul of the user/magazine is missing page",
+    "author": "Pamasich",
+    "version": "0.1.0",
+    "label": "Helpful missing user/magazine page",
+    "desc": "Overhauls the page that's shown when kbin cannot find a user or magazine you're trying to access. Instead of the native 404 error, this addon enhances the page with an explanation and helpful links.",
+    "login": false,
+    "recurs": false,
+    "entrypoint": "missing_actor_info",
+    "page": "general"
+}

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -5,18 +5,40 @@
  * federate the user, as well as providing helpful links to quickly federate the user or
  * access their profile on the original instance.
  * 
- * Implementation notes from Github:
- * - for remote users or communities, there should be instructions on how to initiate 
- * federation and a button to visit it on the original instance.
- * - For local communities, there should be a button to create it.
- * 
  * @param {boolean} isActive Whether the mod has been turned on
  */
 function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
-    const INSTANCE_NAME = window.location.hostname;
+    /**
+     * Separates a resource path into its individual parts, taking it apart in the pattern
+     * `/<type>/<resource>@<domain>`.  
+     * For simplicity with inserting it into text, the `type` will be expanded from u/m
+     * to user/magazine.  
+     * If for some reason the path can't be parsed, `null` is returned.
+     * @param {string} path
+     * @returns {{type: string, domain: string, resource: string} | null}
+     */
+    function separateResourcePath (path) {
+        var output;
+        try {
+            output = path
+                .match(/\/(?<type>u|m)\/(?<resource>\w+)(@(?<domain>\w+\.(?:\w+\.)*\w+))?/)
+                .groups;
+        } catch (e) {
+            output = null;
+        }
+        if (output['type'] == 'u') output['type'] = 'user';
+        else if (output['type'] == 'm') output['type'] = 'magazine';
+        else output = null;
+        return output;
+    }
 
-    // add a function to turn the {page} in these into the isApplicablePage result
-    const TITLE_TEXT = `The requested {page} was not found on ${INSTANCE_NAME}!`;
+    const INSTANCE_NAME = window.location.hostname;
+    const SEPARATED_PATH = separateResourcePath(window.location.pathname);
+    const PAGE_PLACEHOLDER_REGEX = new RegExp('{page}', 'g');
+    const INSTANCE_PLACEHOLDER_REGEX = new RegExp('{instance}', 'g');
+
+    const TITLE_TEXT = `The requested ${SEPARATED_PATH.type} was not found on ${INSTANCE_NAME}!`;
+    /** The text to display when a local user (without \@domain.tld) is accessed. */
     const EXPLAIN_LOCAL_USER = `
         It seems you've tried to access a user from this instance, but such a user does not exist.
         <br/>Please verify you've written their name correctly.
@@ -24,6 +46,7 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         If you meant to access a remote user, you should append their instance's domain after 
         the username.
     `;
+    /** The text to display when a local magazine (without \@domain.tld) is accessed. */
     const EXPLAIN_LOCAL_MAG = `
         It seems you've tried to access a magazine from this instance, but such a magazine does not 
         exist.<br/>
@@ -32,66 +55,74 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         If you meant to access a remote magazine, you should append its instance's domain after the 
         magazine's name.
     `;
+    /** The text to display when a remote actor (user or magazine) is accessed. */
     const EXPLAIN_REMOTE = `
-        It seems you've tried to access a {page} from {instance}, but that {page} is not known to 
-        ${INSTANCE_NAME} yet.
+        It seems you've tried to access a ${SEPARATED_PATH.type} from ${SEPARATED_PATH.domain}, but 
+        that ${SEPARATED_PATH.type} is not known to ${INSTANCE_NAME} yet.
         <br/><br/>
         First, please double check you haven't made any spelling errors.<br/>
         If that doesn't resolve the issue, then you're probably the first one from
-        ${INSTANCE_NAME} to express interest in this {page}.
+        ${INSTANCE_NAME} to express interest in this ${SEPARATED_PATH.type}.
         <br/><br/>
-        To prompt ${INSTANCE_NAME} to create a {page} page for this URL, search for it on the 
-        search page. This URL will then be available within moments, provided communication
-        between the instances works correctly.<br/>
-        To actually see new posts federated over however, you will need to subscribe to the {page}.
+        To prompt ${INSTANCE_NAME} to create a ${SEPARATED_PATH.type} page for this URL, search for 
+        it on the search page. This URL will then be available within moments, provided 
+        communication between the instances works correctly.<br/>
+        To actually see new posts federated over however, you will need to subscribe to 
+        the ${SEPARATED_PATH.type}.
     `;
     
     if (isActive) setup();
     //else teardown();
 
     function setup () {
-        const page = isApplicablePage();
-        if (!page) return;
+        // Preconditions
+        if (SEPARATED_PATH == null) return;
+        if (!document.querySelector('.page-error')) return;
+        if (!document.title.includes('404')) return;
 
         const parent = getErrorContainer();
         resetContainer(parent);
-        addContents(parent, page);
-    }
-
-    /**
-     * @param {HTMLElement} parent
-     * @param {'user' | 'magazine'} pageType
-     */
-    function addContents (parent, pageType) {
-        const replacePage = new RegExp('{page}', 'g');
-        parent.append(buildTitle(TITLE_TEXT.replace(replacePage, pageType)));
-        const separatedPath = separateResourcePath(window.location.pathname);
-        var text;
-        if (separatedPath.domain != undefined) 
-            text = EXPLAIN_REMOTE.replace(new RegExp('{instance}', 'g'), separatedPath.domain);
-        else if (pageType == 'user') text = EXPLAIN_LOCAL_USER;
-        else text = EXPLAIN_LOCAL_MAG;
-        text = text.replace(replacePage, pageType);
-        parent.append(buildParagraph(text));
-        addControls(parent, pageType);
-    }
-
-    /**
-     * @param {HTMLElement} parent
-     * @param {'user' | 'magazine'} pageType
-     */
-    function addControls (parent, pageType) {
+        parent.append(buildTitle());
+        parent.append(buildParagraph(selectAppropriateText()));
         parent.append(buildEditURLUI());
-        const separatedPath = separateResourcePath(window.location.pathname);
-        if (separatedPath.domain != undefined) {
+        if (SEPARATED_PATH.domain != undefined) {
             parent.append(buildSearchButton());
             (async () => {
                 const btn = await buildOriginalLinkButton();
                 if (btn != undefined) parent.append(btn);
             })();
-        } else if (pageType == 'magazine') {
+        } else if (SEPARATED_PATH.type == 'magazine') {
             parent.append(buildCreateMagazineButton());
         }
+    }
+
+    /**
+     * Strings here may use placeholders like '{page}' or '{instance}' which are meant to be filled
+     * in at a later point. Which would be now, that's this function's job.
+     * 
+     * @param {string} text
+     */
+    function replacePlaceholders (text) {
+        return text
+            .replace(PAGE_PLACEHOLDER_REGEX, SEPARATED_PATH.type)
+            .replace(INSTANCE_PLACEHOLDER_REGEX, SEPARATED_PATH.domain);
+    }
+
+    /**
+     * Based on the circumstances, chooses which text to display to the user.
+     */
+    function selectAppropriateText () {
+        if (SEPARATED_PATH.domain != undefined) return EXPLAIN_REMOTE;
+        else if (SEPARATED_PATH.type == 'user') return EXPLAIN_LOCAL_USER;
+        else return EXPLAIN_LOCAL_MAG;
+    }
+
+    function buildTitle () {
+        const title = create('h2');
+        title.textContent = replacePlaceholders(TITLE_TEXT);
+        title.style.color = 'var(--kbin-text-muted-color)';
+        title.style.marginBlockStart = 0;
+        return title;
     }
 
     /** @returns {HTMLAnchorElement} */
@@ -106,122 +137,131 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         return btn;
     }
 
-    /** @returns {HTMLAnchorElement} */
+    /**
+     * Creates a button which points to the resouece on its home instance.  
+     * The webfinger lookup in this function currently does not work with Lemmy, which claims
+     * it is a "Bad Request". It's been successfully tested with both mbin and Mastodon however.
+     * 
+     * @returns {HTMLAnchorElement | undefined}
+     */
     async function buildOriginalLinkButton () {
-        // this function does NOT currently work with Lemmy
         const btn = buildButton("View on original instance", 'placeholder');
-        const path = separateResourcePath(window.location.pathname);
-        const domain = path.domain;
-        const resourceName = `${path.resource}@${path.domain}`;
+        const domain = SEPARATED_PATH.domain;
+        const resourceName = `${SEPARATED_PATH.resource}@${SEPARATED_PATH.domain}`;
         const url = `https://${domain}/.well-known/webfinger?resource=${resourceName}`;
         const headers = new Headers({ 'Accept': 'application/activity+json' });
 
         const response = await fetch(url, { method: 'GET', headers });
         if (response.ok == false) return undefined;
         const data = await response.json();
-        data['links'].forEach((link) => {
-            if (link['rel'] == 'self') {
-                btn.href = link['href'];
-                return;
-            }
-        });
+        // look through the webfinger results to get the user's homepage
+        btn.href = data['links'].find((link) => link['rel'] == 'self')['href'];
         return btn;
     }
 
-    /** @returns {HTMLAnchorElement} */
+    /**
+     * Creates a button which acts as a shortcut to the search page, with the current
+     * resource path already filled in.
+     * 
+     * @returns {HTMLAnchorElement}
+     */
     function buildSearchButton () {
-        const path = separateResourcePath(window.location.pathname);
-        return buildButton("Go to search", `/search?q=${path.resource}@${path.domain}`);
+        return buildButton(
+            "Go to search", `/search?q=${SEPARATED_PATH.resource}@${SEPARATED_PATH.domain}`
+        );
     }
 
-    /** @returns {HTMLAnchorElement} */
+    /**
+     * Creates a button which acts as a shortcut to the magazine creation page.  
+     * 
+     * @returns {HTMLAnchorElement}
+     */
     function buildCreateMagazineButton () {
         return buildButton("Create New Magazine", '/newMagazine');
     }
 
-    /** @returns {HTMLElement} @param {'user' | 'magazine'} pageType  */
-    function buildEditURLUI (pageType) {
-        const path = separateResourcePath(window.location.pathname);
-        /** @type {HTMLInputElement} */
-        const nameField = create('input');
-        /** @type {HTMLInputElement} */
-        const domainField = create('input');
-        const reloadBtn = create('a');
-        reloadBtn.textContent = "Reload";
-        nameField.value = path.resource;
-        domainField.value = path.domain ?? "";
+    /**
+     * Creates a UI through which the current resource URL can be edited, and the edited
+     * version reloaded.  
+     * This is meant as a feature for less tech savvy users who might not
+     * understand urls too well, or for mobile users where editing the url directly, in my
+     * personal experience, is quite a lot more annoying than on PC.
+     * 
+     * @returns {HTMLElement}
+     */
+    function buildEditURLUI () {
+        /** @type {HTMLInputElement} */ const nameField = create('input');
+        /** @type {HTMLInputElement} */ const domainField = create('input');
+        nameField.value = SEPARATED_PATH.resource;
+        domainField.value = SEPARATED_PATH.domain ?? "";
         domainField.placeholder = "(when local, leave blank)";
-        reloadBtn.style.marginLeft = '.5rem';
-        reloadBtn.className = 'btn btn-link btn__primary';
-        reloadBtn.style.paddingTop = '0.2rem';
-        reloadBtn.style.paddingBottom = '0.3rem';
 
         function getNewLink () {
-            var value = (pageType == 'user' ? '/u/' : '/m/') + nameField.value;
+            // type is either 'user' or 'magazine', we want the first letter of whichever it is
+            var value = `/${SEPARATED_PATH.type.slice(0,1)}/${nameField.value}`;
             if (domainField.value != '') value += '@' + domainField.value;
             return value;
         }
-        reloadBtn.href = getNewLink();
+        /** @returns {HTMLAnchorElement} */
+        function buildReloadButton () {
+            const reloadBtn = Object.assign(create('a'), {
+                textContent: "Reload",
+                className: 'btn btn-link btn__primary',
+                href: getNewLink()
+            });
+            Object.assign(reloadBtn.style, {
+                marginLeft: '0.5rem',
+                paddingTop: '0.2rem',
+                paddingBottom: '0.3rem'
+            });
+            return reloadBtn;
+        }
+
+        const reloadBtn = buildReloadButton();
         nameField.addEventListener('input', () => reloadBtn.href = getNewLink());
         domainField.addEventListener('input', () => reloadBtn.href = getNewLink());
 
         const div = create('div');
-        div.style.color = 'inherit';
-        div.style.fontSize = 'var(--kbin-body-font-size)';
-        div.style.fontWeight = 'var(--kbin-body-font-weight)';
-        div.style.marginTop = '3rem';
+        Object.assign(div.style, {
+            color: 'inherit',
+            fontSize: 'var(--kbin-body-font-size)',
+            fontWeight: 'var(--kbin-body-font-weight)',
+            marginTop: '3rem'
+        });
         div.append(
             "Edit User Name & Instance Domain:", 
             create("br"), 
-            nameField, 
-            "@", 
-            domainField, 
-            reloadBtn);
+            nameField, "@", domainField, reloadBtn);
         return div;
     }
 
-    /** @returns {HTMLElement} @param {string} e */
+    /**
+     * Shortcut function to creating a new element.
+     * 
+     * @param {string} e The HTML tag to create
+     */
     function create (e) {
         return document.createElement(e);
     }
 
     /**
-     * @param {string} path
-     * @returns {{domain: string, resource: string}}
-     */
-    function separateResourcePath (path) {
-        return path
-            .slice(3)
-            .match(/(?<resource>\w+)(@(?<domain>\w+\.(?:\w+\.)*\w+))?/)
-            .groups;
-    }
-
-    /**
-     * @param {string} text
+     * @param {string} text The text to display
      * @returns {HTMLElement}
      */
     function buildParagraph (text) {
         const p = create('p');
-        p.innerHTML = text;
+        p.innerHTML = replacePlaceholders(text);
         p.style.color = 'inherit';
         p.style.fontSize = 'var(--kbin-body-font-size)';
         p.style.fontWeight = 'var(--kbin-body-font-weight)';
         return p;
     }
 
-    /** 
-     * @param {string} text
-     * @returns {HTMLElement}
+    /**
+     * Removes all elements from a given container, to return it to being a blank slate.
+     * 
+     * @param {HTMLElement} container
      */
-    function buildTitle (text) {
-        const title = create('h2');
-        title.innerHTML = text;
-        title.style.color = 'var(--kbin-text-muted-color)';
-        title.style.marginBlockStart = 0;
-        return title;
-    }
-
-    /** @param {HTMLElement} container */
     function resetContainer (container) {
         container.style.textAlign = 'start';
         Array.from(container.childNodes).forEach((child) => {
@@ -229,17 +269,12 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         });
     }
 
-    /** @returns {HTMLElement} */
+    /**
+     * Retrieves from the page the container which contains the 404 error message.
+     * 
+     * @returns {HTMLElement}
+     */
     function getErrorContainer () {
         return document.querySelector('#content');
-    }
-
-    function isApplicablePage () {
-        if (!document.querySelector('.page-error')) return false;
-        if (!document.title.includes('404')) return false;
-        const url = window.location.pathname;
-        if (url.includes('/u/')) return 'user';
-        if (url.includes('/m/')) return 'magazine';
-        return false;
     }
 }

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -1,3 +1,5 @@
+const exp = require("constants");
+
 /**
  * The page shown when trying to access a user or magazine that hasn't been federated to the
  * instance yet can be quite unhelpful. It simply shows a 404 error.
@@ -12,7 +14,69 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
     else teardown();
 
     function setup () {
+        if (!document.querySelector('.page-error')) return;
+        if (!document.title.includes('404')) return;
+        const url = window.location.pathname;
+        const isUser = url.includes('/u/');
+        const isMagazine = url.includes('/m/');
+        if (isUser || isMagazine) {
+            /** @type {HTMLElement} */
+            const parent = document.querySelector('#content');
+            parent.style.textAlign = 'start';
+            Array.from(parent.childNodes).forEach((child) => {
+                child.remove()
+            });
 
+            const instance = window.location.hostname;
+
+            const title = document.createElement('h2');
+            title.textContent = 
+                `The requested ${isUser ? "user" : "magazine"} does not exist on ${instance}!`;
+            title.style.color = "var(--kbin-text-muted-color)";
+            parent.append(title);
+
+            const explanation = document.createElement('p');
+            const pageInstruction = document.createElement('p');
+            const federationInstruction = document.createElement('p');
+            if (isUser) {
+                explanation.textContent = `The user you tried to access doesn't exist on this `
+                    + `instance yet. This is most likely because ${instance} hasn't yet been `
+                    + `told to federate the user. To avoid overburdening its server, `
+                    + `${instance} only federates users and magazines its local users are `
+                    + `interested in.`
+                pageInstruction.textContent = `To make this URL work, do a search for the user `
+                    + `once. There's a button on this page which does that for you. This prompts `
+                    + `${instance} to look the user up and build a page to display at this URL. `
+                    + `The URL should then work shortly afterwards.`
+                federationInstruction.textContent = `Simply looking them up won't cause `
+                    + `${instance} to start federating in new posts from the user though. `
+                    + `To achieve that, at least one person needs to be following the user `
+                    + `from your instance.`
+            } else {
+                explanation.textContent = `The magazine you tried to access doesn't exist on this `
+                    + `instance yet. This is most likely because ${instance} hasn't yet been `
+                    + `told to federate the magazine. To avoid overburdening its server, `
+                    + `${instance} only federates users and magazines its local users are `
+                    + `interested in.`
+                pageInstruction.textContent = `To make this URL work, do a search for the magazine `
+                    + `once. There's a button on this page which does that for you. This prompts `
+                    + `${instance} to look the magazine up and build a page to display at this `
+                    + `URL. The URL should then work shortly afterwards.`
+                federationInstruction.textContent = `Simply looking them up won't cause `
+                    + `${instance} to start federating in new posts from the magazine though. `
+                    + `To achieve that, at least one person needs to be subscribed to the magazine `
+                    + `from your instance.`
+            }
+            explanation.style.fontSize = "var(--kbin-body-font-size)";
+            pageInstruction.style.fontSize = "var(--kbin-body-font-size)";
+            federationInstruction.style.fontSize = "var(--kbin-body-font-size)";
+            explanation.style.fontWeight = "var(--kbin-body-font-weight)";
+            pageInstruction.style.fontWeight = "var(--kbin-body-font-weight)";
+            federationInstruction.style.fontWeight = "var(--kbin-body-font-weight)";
+            parent.append(explanation);
+            parent.append(pageInstruction);
+            parent.append(federationInstruction);
+        }
     }
 
     function teardown () {

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -81,6 +81,38 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
      */
     function addControls (parent, pageType) {
         parent.append(buildEditURLUI());
+        const separatedPath = separateResourcePath(window.location.pathname);
+        if (separatedPath.domain != undefined) {
+            // add the buttons for remote actors
+            parent.append(buildSearchButton());
+        } else if (pageType == 'magazine') {
+            parent.append(buildCreateMagazineButton());
+        }
+    }
+
+    /** @returns {HTMLElement} */
+    function buildSearchButton () {
+        /** @type {HTMLAnchorElement} */
+        const goToSearchBtn = create('a');
+        goToSearchBtn.textContent = "Go to Search";
+        goToSearchBtn.className = 'btn btn-link btn__secondary';
+        const path = separateResourcePath(window.location.pathname);
+        goToSearchBtn.href = `/search?q=${path.resource}@${path.domain}`;
+        goToSearchBtn.style.marginTop = '1rem';
+        goToSearchBtn.style.display = 'inline-block';
+        return goToSearchBtn;
+    }
+
+    /** @returns {HTMLElement} */
+    function buildCreateMagazineButton () {
+        /** @type {HTMLAnchorElement} */
+        const createMagBtn = create('a');
+        createMagBtn.textContent = "Create New Magazine";
+        createMagBtn.className = 'btn btn-link btn__secondary';
+        createMagBtn.href = `/newMagazine`;
+        createMagBtn.style.marginTop = '1rem';
+        createMagBtn.style.display = 'inline-block';
+        return createMagBtn;
     }
 
     /** @returns {HTMLElement} @param {'user' | 'magazine'} pageType  */

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -1,0 +1,21 @@
+/**
+ * The page shown when trying to access a user or magazine that hasn't been federated to the
+ * instance yet can be quite unhelpful. It simply shows a 404 error.
+ * This mod overhauls the page so it informs the user about what's going on and how they can
+ * federate the user, as well as providing helpful links to quickly federate the user or
+ * access their profile on the original instance.
+ * 
+ * @param {boolean} isActive Whether the mod has been turned on
+ */
+function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
+    if (isActive) setup();
+    else teardown();
+
+    function setup () {
+
+    }
+
+    function teardown () {
+
+    }
+}

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -21,8 +21,8 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         It seems you've tried to access a user from this instance, but such a user does not exist.
         <br/>Please verify you've written their name correctly.
         <br/><br/>
-        If you meant to access a remote user, you should append their instance after the username.
-        <br/><br/>
+        If you meant to access a remote user, you should append their instance's domain after 
+        the username.<br/><br/>
         <add form to edit in a domain, and a retry button>
     `;
     const EXPLAIN_LOCAL_MAG = `
@@ -30,7 +30,7 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         exist.<br/>
         Please verify you've written its name correctly.
         <br/><br/>
-        If you meant to access a remote magazine, you should append its instance after the 
+        If you meant to access a remote magazine, you should append its instance's domain after the 
         magazine's name.
         <br/><br/>
         <add form to edit in a domain, and a retry button><br/>
@@ -46,7 +46,7 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         <br/><br/>
         To prompt ${INSTANCE_NAME} to create a {page} page for this URL, search for it on the 
         search page. This URL will then be available within moments.<br/>
-        To actually see new posts federated over however, you'll need to subscribe to the {page}.
+        To actually see new posts federated over however, you will need to subscribe to the {page}.
         <br/><br/>
         <add shortcut to search the magazine or user><br/>
         <add link to the remote page>
@@ -79,6 +79,54 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         else text = EXPLAIN_LOCAL_MAG;
         text = text.replace(replacePage, pageType);
         parent.append(buildParagraph(text));
+        addControls(parent, pageType);
+    }
+
+    /**
+     * @param {HTMLElement} parent
+     * @param {'user' | 'magazine'} pageType
+     */
+    function addControls (parent, pageType) {
+        parent.append(buildEditURLUI());
+    }
+
+    /** @returns {HTMLElement} @param {'user' | 'magazine'} pageType  */
+    function buildEditURLUI (pageType) {
+        const path = separateResourcePath(window.location.pathname);
+        /** @type {HTMLInputElement} */
+        const nameField = create('input');
+        /** @type {HTMLInputElement} */
+        const domainField = create('input');
+        const reloadBtn = create('a');
+        reloadBtn.textContent = "Reload";
+        nameField.value = path.resource;
+        domainField.value = path.domain ?? "";
+        domainField.placeholder = "(when local, leave blank)";
+        reloadBtn.style.marginLeft = '.5rem';
+        reloadBtn.className = 'btn btn-link btn__primary';
+        reloadBtn.style.paddingTop = '0.2rem';
+        reloadBtn.style.paddingBottom = '0.3rem';
+
+        function getNewLink () {
+            var value = (pageType == 'user' ? '/u/' : '/m/') + nameField.value;
+            if (domainField.value != '') value += '@' + domainField.value;
+            return value;
+        }
+        reloadBtn.href = getNewLink();
+        nameField.addEventListener('input', () => reloadBtn.href = getNewLink());
+        domainField.addEventListener('input', () => reloadBtn.href = getNewLink());
+
+        const div = create('div');
+        div.style.color = 'inherit';
+        div.style.fontSize = 'var(--kbin-body-font-size)';
+        div.style.fontWeight = 'var(--kbin-body-font-weight)';
+        div.append("Edit Name & Domain:", create("br"), nameField, "@", domainField, reloadBtn);
+        return div;
+    }
+
+    /** @returns {HTMLElement} @param {string} e */
+    function create (e) {
+        return document.createElement(e);
     }
 
     /**
@@ -97,7 +145,7 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
      * @returns {HTMLElement}
      */
     function buildParagraph (text) {
-        const p = document.createElement('p');
+        const p = create('p');
         p.innerHTML = text;
         p.style.color = 'inherit';
         p.style.fontSize = 'var(--kbin-body-font-size)';
@@ -110,7 +158,7 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
      * @returns {HTMLElement}
      */
     function buildTitle (text) {
-        const title = document.createElement('h2');
+        const title = create('h2');
         title.innerHTML = text;
         title.style.color = 'var(--kbin-text-muted-color)';
         title.style.marginBlockStart = 0;

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -22,8 +22,7 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         <br/>Please verify you've written their name correctly.
         <br/><br/>
         If you meant to access a remote user, you should append their instance's domain after 
-        the username.<br/><br/>
-        <add form to edit in a domain, and a retry button>
+        the username.
     `;
     const EXPLAIN_LOCAL_MAG = `
         It seems you've tried to access a magazine from this instance, but such a magazine does not 
@@ -32,9 +31,6 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         <br/><br/>
         If you meant to access a remote magazine, you should append its instance's domain after the 
         magazine's name.
-        <br/><br/>
-        <add form to edit in a domain, and a retry button><br/>
-        <add shortcut button to create the magazine>
     `;
     const EXPLAIN_REMOTE = `
         It seems you've tried to access a {page} from {instance}, but that {page} is not known to 
@@ -47,9 +43,6 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         To prompt ${INSTANCE_NAME} to create a {page} page for this URL, search for it on the 
         search page. This URL will then be available within moments.<br/>
         To actually see new posts federated over however, you will need to subscribe to the {page}.
-        <br/><br/>
-        <add shortcut to search the magazine or user><br/>
-        <add link to the remote page>
     `;
     
     if (isActive) setup();
@@ -120,7 +113,14 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         div.style.color = 'inherit';
         div.style.fontSize = 'var(--kbin-body-font-size)';
         div.style.fontWeight = 'var(--kbin-body-font-weight)';
-        div.append("Edit Name & Domain:", create("br"), nameField, "@", domainField, reloadBtn);
+        div.style.marginTop = '3rem';
+        div.append(
+            "Edit User Name & Instance Domain:", 
+            create("br"), 
+            nameField, 
+            "@", 
+            domainField, 
+            reloadBtn);
         return div;
     }
 

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -41,7 +41,8 @@ function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
         ${INSTANCE_NAME} to express interest in this {page}.
         <br/><br/>
         To prompt ${INSTANCE_NAME} to create a {page} page for this URL, search for it on the 
-        search page. This URL will then be available within moments.<br/>
+        search page. This URL will then be available within moments, provided communication
+        between the instances works correctly.<br/>
         To actually see new posts federated over however, you will need to subscribe to the {page}.
     `;
     

--- a/mods/missing_actor_info/missing_actor_info.user.js
+++ b/mods/missing_actor_info/missing_actor_info.user.js
@@ -1,5 +1,3 @@
-const exp = require("constants");
-
 /**
  * The page shown when trying to access a user or magazine that hasn't been federated to the
  * instance yet can be quite unhelpful. It simply shows a 404 error.
@@ -7,79 +5,137 @@ const exp = require("constants");
  * federate the user, as well as providing helpful links to quickly federate the user or
  * access their profile on the original instance.
  * 
+ * Implementation notes from Github:
+ * - for remote users or communities, there should be instructions on how to initiate 
+ * federation and a button to visit it on the original instance.
+ * - For local communities, there should be a button to create it.
+ * 
  * @param {boolean} isActive Whether the mod has been turned on
  */
 function missingActorInfo (isActive) { // eslint-disable-line no-unused-vars
+    const INSTANCE_NAME = window.location.hostname;
+
+    // add a function to turn the {page} in these into the isApplicablePage result
+    const TITLE_TEXT = `The requested {page} was not found on ${INSTANCE_NAME}!`;
+    const EXPLAIN_LOCAL_USER = `
+        It seems you've tried to access a user from this instance, but such a user does not exist.
+        <br/>Please verify you've written their name correctly.
+        <br/><br/>
+        If you meant to access a remote user, you should append their instance after the username.
+        <br/><br/>
+        <add form to edit in a domain, and a retry button>
+    `;
+    const EXPLAIN_LOCAL_MAG = `
+        It seems you've tried to access a magazine from this instance, but such a magazine does not 
+        exist.<br/>
+        Please verify you've written its name correctly.
+        <br/><br/>
+        If you meant to access a remote magazine, you should append its instance after the 
+        magazine's name.
+        <br/><br/>
+        <add form to edit in a domain, and a retry button><br/>
+        <add shortcut button to create the magazine>
+    `;
+    const EXPLAIN_REMOTE = `
+        It seems you've tried to access a {page} from {instance}, but that {page} is not known to 
+        ${INSTANCE_NAME} yet.
+        <br/><br/>
+        First, please double check you haven't made any spelling errors.<br/>
+        If that doesn't resolve the issue, then you're probably the first one from
+        ${INSTANCE_NAME} to express interest in this {page}.
+        <br/><br/>
+        To prompt ${INSTANCE_NAME} to create a {page} page for this URL, search for it on the 
+        search page. This URL will then be available within moments.<br/>
+        To actually see new posts federated over however, you'll need to subscribe to the {page}.
+        <br/><br/>
+        <add shortcut to search the magazine or user><br/>
+        <add link to the remote page>
+    `;
+    
     if (isActive) setup();
-    else teardown();
+    //else teardown();
 
     function setup () {
-        if (!document.querySelector('.page-error')) return;
-        if (!document.title.includes('404')) return;
-        const url = window.location.pathname;
-        const isUser = url.includes('/u/');
-        const isMagazine = url.includes('/m/');
-        if (isUser || isMagazine) {
-            /** @type {HTMLElement} */
-            const parent = document.querySelector('#content');
-            parent.style.textAlign = 'start';
-            Array.from(parent.childNodes).forEach((child) => {
-                child.remove()
-            });
+        const page = isApplicablePage();
+        if (!page) return;
 
-            const instance = window.location.hostname;
-
-            const title = document.createElement('h2');
-            title.textContent = 
-                `The requested ${isUser ? "user" : "magazine"} does not exist on ${instance}!`;
-            title.style.color = "var(--kbin-text-muted-color)";
-            parent.append(title);
-
-            const explanation = document.createElement('p');
-            const pageInstruction = document.createElement('p');
-            const federationInstruction = document.createElement('p');
-            if (isUser) {
-                explanation.textContent = `The user you tried to access doesn't exist on this `
-                    + `instance yet. This is most likely because ${instance} hasn't yet been `
-                    + `told to federate the user. To avoid overburdening its server, `
-                    + `${instance} only federates users and magazines its local users are `
-                    + `interested in.`
-                pageInstruction.textContent = `To make this URL work, do a search for the user `
-                    + `once. There's a button on this page which does that for you. This prompts `
-                    + `${instance} to look the user up and build a page to display at this URL. `
-                    + `The URL should then work shortly afterwards.`
-                federationInstruction.textContent = `Simply looking them up won't cause `
-                    + `${instance} to start federating in new posts from the user though. `
-                    + `To achieve that, at least one person needs to be following the user `
-                    + `from your instance.`
-            } else {
-                explanation.textContent = `The magazine you tried to access doesn't exist on this `
-                    + `instance yet. This is most likely because ${instance} hasn't yet been `
-                    + `told to federate the magazine. To avoid overburdening its server, `
-                    + `${instance} only federates users and magazines its local users are `
-                    + `interested in.`
-                pageInstruction.textContent = `To make this URL work, do a search for the magazine `
-                    + `once. There's a button on this page which does that for you. This prompts `
-                    + `${instance} to look the magazine up and build a page to display at this `
-                    + `URL. The URL should then work shortly afterwards.`
-                federationInstruction.textContent = `Simply looking them up won't cause `
-                    + `${instance} to start federating in new posts from the magazine though. `
-                    + `To achieve that, at least one person needs to be subscribed to the magazine `
-                    + `from your instance.`
-            }
-            explanation.style.fontSize = "var(--kbin-body-font-size)";
-            pageInstruction.style.fontSize = "var(--kbin-body-font-size)";
-            federationInstruction.style.fontSize = "var(--kbin-body-font-size)";
-            explanation.style.fontWeight = "var(--kbin-body-font-weight)";
-            pageInstruction.style.fontWeight = "var(--kbin-body-font-weight)";
-            federationInstruction.style.fontWeight = "var(--kbin-body-font-weight)";
-            parent.append(explanation);
-            parent.append(pageInstruction);
-            parent.append(federationInstruction);
-        }
+        const parent = getErrorContainer();
+        resetContainer(parent);
+        addContents(parent, page);
     }
 
-    function teardown () {
+    /**
+     * @param {HTMLElement} parent
+     * @param {'user' | 'magazine'} pageType
+     */
+    function addContents (parent, pageType) {
+        const replacePage = new RegExp('{page}', 'g');
+        parent.append(buildTitle(TITLE_TEXT.replace(replacePage, pageType)));
+        const separatedPath = separateResourcePath(window.location.pathname);
+        var text;
+        if (separatedPath.domain != undefined) 
+            text = EXPLAIN_REMOTE.replace(new RegExp('{instance}', 'g'), separatedPath.domain);
+        else if (pageType == 'user') text = EXPLAIN_LOCAL_USER;
+        else text = EXPLAIN_LOCAL_MAG;
+        text = text.replace(replacePage, pageType);
+        parent.append(buildParagraph(text));
+    }
 
+    /**
+     * @param {string} path
+     * @returns {{domain: string, resource: string}}
+     */
+    function separateResourcePath (path) {
+        return path
+            .slice(3)
+            .match(/(?<resource>\w+)(@(?<domain>\w+\.(?:\w+\.)*\w+))?/)
+            .groups;
+    }
+
+    /**
+     * @param {string} text
+     * @returns {HTMLElement}
+     */
+    function buildParagraph (text) {
+        const p = document.createElement('p');
+        p.innerHTML = text;
+        p.style.color = 'inherit';
+        p.style.fontSize = 'var(--kbin-body-font-size)';
+        p.style.fontWeight = 'var(--kbin-body-font-weight)';
+        return p;
+    }
+
+    /** 
+     * @param {string} text
+     * @returns {HTMLElement}
+     */
+    function buildTitle (text) {
+        const title = document.createElement('h2');
+        title.innerHTML = text;
+        title.style.color = 'var(--kbin-text-muted-color)';
+        title.style.marginBlockStart = 0;
+        return title;
+    }
+
+    /** @param {HTMLElement} container */
+    function resetContainer (container) {
+        container.style.textAlign = 'start';
+        Array.from(container.childNodes).forEach((child) => {
+            child.remove();
+        });
+    }
+
+    /** @returns {HTMLElement} */
+    function getErrorContainer () {
+        return document.querySelector('#content');
+    }
+
+    function isApplicablePage () {
+        if (!document.querySelector('.page-error')) return false;
+        if (!document.title.includes('404')) return false;
+        const url = window.location.pathname;
+        if (url.includes('/u/')) return 'user';
+        if (url.includes('/m/')) return 'magazine';
+        return false;
     }
 }


### PR DESCRIPTION
#### Related issue on my repo

- Pamasich/kbin-kes#25

#### Original idea

- https://codeberg.org/Kbin/kbin-core/issues/1341

## Explanation

This mod aims to replace the generic 404 Not Found page when trying to access a non-existing actor, with an explanation and helpful links tailored to the exact situation (remote vs local user or magazine). This is primarily meant to clarify with remote actors that they simply aren't federated yet and the user CAN do something to resolve that.

## Todo (before 1.0)

- [x] Add buttons
  - [x] Add button when accessing a non-existing local magazine to create it
  - [x] Add button when accessing a non-federated remote actor to access its original page
  - [x] Add button when accessing a non-federated remote actor to search for it (which is the first step to federating it)
  - [x] Add a text field to edit the target's name and domain and try again
- [ ] Implement teardown
- [ ] Test the mod with KES
- [x] Refactoring & documenting

