### PR TITLE
Settings Button Fix

### DIFF
--- a/kes.user.js
+++ b/kes.user.js
@@ -162,7 +162,8 @@ function constructMenu (json, layoutArr, isNew) {
         }
         let kbinContainer
         if (window.innerWidth > 576) {
-            kbinContainer = document.querySelector('.kbin-container > menu');
+            kbinContainer = document.querySelector('.kbin-container > menu')
+                ?? document.querySelector('.mbin-container > menu');
         } else {
             kbinContainer = document.querySelector('.sidebar-options > .section > menu > ul')
         }


### PR DESCRIPTION
This is a fix for the settings button not being injected anymore.

The issue occurs because Mbin renamed the `.kbin-container` class to `.mbin-container` in its latest version. The button was looking for the former specifically, now it checks both.

