### PR TITLE
[FIX] The (profile) dropdown mod's links weren't working

### DIFF
--- a/mods/dropdown/dropdown.json
+++ b/mods/dropdown/dropdown.json
@@ -1,7 +1,7 @@
 {
   "name": "Dropdown links",
   "author": "shazbot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "label": "Dropdown links",
   "login": false,
   "recurs": false,

--- a/mods/dropdown/dropdown.user.js
+++ b/mods/dropdown/dropdown.user.js
@@ -31,7 +31,7 @@ function dropdownEntry (toggle) { // eslint-disable-line no-unused-vars
 
         // event listener
         $(document).on('change', '#dropdown-select', function () {
-            const page = $('#dropdown-select').val();
+            const page = $('#dropdown-select').val().toLowerCase();
             const pref = 'https://' + window.location.hostname + '/u/'
             const finalUrl = pref + user + "/" + page;
             window.location = finalUrl;


### PR DESCRIPTION
The links in the dropdown were leading to 404 pages because mbin URLs are case sensitive and all lowercase, while this mod's links are capitalized. So I added a `toLowerCase()`.