### PR TITLE
[FIX] Improved hide_reputation's item selection logic so the right item gets hidden

### DIFF
--- a/mods/hide_reputation/hide_reputation.json
+++ b/mods/hide_reputation/hide_reputation.json
@@ -1,7 +1,7 @@
 {
   "name": "Hide Reputation",
   "author": "artillect",
-  "version": "0.2",
+  "version": "0.3",
   "label": "Hide reputation",
   "desc": "Hide reputation on users' profiles",
   "login": false,

--- a/mods/hide_reputation/hide_reputation.user.js
+++ b/mods/hide_reputation/hide_reputation.user.js
@@ -2,17 +2,18 @@ function hideReputation (toggle) { //eslint-disable-line no-unused-vars
     // ==UserScript==
     // @name         kbin Vote Hider
     // @namespace    https://github.com/aclist
-    // @version      0.2
+    // @version      0.3
     // @description  Hide upvotes, downvotes, and karma
     // @author       artillect
     // @match        https://kbin.social/*
     // @license      MIT
     // ==/UserScript==
+    const itemSelector = 'li:has(a[href$="/reputation/threads"])'
     if (toggle) {
-        $('#sidebar > section.section.user-info > ul > li:nth-child(2)').hide();
-        document.styleSheets[0].addRule('.user-popover ul li:nth-of-type(2)','display:none')
+        $(`#sidebar > section.section.user-info > ul > ${itemSelector}`).hide()
+        document.styleSheets[0].addRule(`.user-popover ul ${itemSelector}`,'display:none')
     } else {
-        $('#sidebar > section.section.user-info > ul > li:nth-child(2)').show();
-        document.styleSheets[0].addRule('.user-popover ul li:nth-of-type(2)','display:initial')
+        $(`#sidebar > section.section.user-info > ul > ${itemSelector}`).show()
+        document.styleSheets[0].addRule(`.user-popover ul ${itemSelector}`,'display:initial')
     }
 }


### PR DESCRIPTION
Mbin has added additional items to the menus where hide_reputation applies, but it was removing the reputation by an explicit index. Since the new items offset the intended one, this caused the wrong item to be removed.

I changed the logic so it uses the URL rather than an index. Might still change in the future, but it's far less likely.