### PR TITLE
[FIX] Collapsible Comments CSS was too broadly defined in some places

### DIFF
--- a/mods/improved_collapsible_comments/improved_collapsible_comments.json
+++ b/mods/improved_collapsible_comments/improved_collapsible_comments.json
@@ -1,7 +1,7 @@
 {
   "name": "Collapsible comments",
   "author": "artillect",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "label": "Collapsible comments",
   "desc": "Collapse comments by clicking on the bars to their left.",
   "login": false,

--- a/mods/improved_collapsible_comments/improved_collapsible_comments.json
+++ b/mods/improved_collapsible_comments/improved_collapsible_comments.json
@@ -3,7 +3,7 @@
   "author": "artillect",
   "version": "1.4.0",
   "label": "Collapsible comments",
-  "desc": "Collapse comments by clicking on their headers, and the bars to their left.",
+  "desc": "Collapse comments by clicking on the bars to their left.",
   "login": false,
   "recurs": false,
   "entrypoint": "improved_collapsible_comments",

--- a/mods/improved_collapsible_comments/improved_collapsible_comments.user.js
+++ b/mods/improved_collapsible_comments/improved_collapsible_comments.user.js
@@ -19,7 +19,7 @@ function initCollapsibleComments (toggle, mutation) { // eslint-disable-line no-
             padding-bottom: 4px !important;
         }
 
-        .comments div {
+        .comments > div[class^="comment-line--"] {
             border-left: none !important;
         }
         .entry-comment .kes-collapse-children {
@@ -211,7 +211,7 @@ function initCollapsibleComments (toggle, mutation) { // eslint-disable-line no-
         `;
         for (let i = 1; i < 10; i++) {
             style += `
-            blockquote.comment-level--${i} {
+            blockquote:not(.post-comment).comment-level--${i} {
                 margin-left: 0 !important;
             }
             `;


### PR DESCRIPTION
Some of the CSS from this mod was applied in cases where it shouldn't.

- The left border of the square avatar style was cut off because of the comment line removal CSS being too broad and applying to ALL divs inside the .comments element.

- On some profile pages where the bulk of the script didn't apply, especially in regards to microblog posts, it still pushed all replies to the left, killing the visual hierarchy. 

In this PR I fixed those two issues and also adjusted the description to be more truthful. It mentioned that comments can be collapsed by clicking on their header, but that feature didn't get implemented in the KES version.