### PR TITLE
Fixed issues with Federation Awareness's cleanup

### DIFF
--- a/mods/kbin_federation_awareness/kbin_federation_awareness.json
+++ b/mods/kbin_federation_awareness/kbin_federation_awareness.json
@@ -1,7 +1,7 @@
 {
   "name": "kbin-federation-awareness",
   "author": "@Ori@sacredori.net",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "label": "Federation Awareness",
   "login": false,
   "recurs": true,

--- a/mods/kbin_federation_awareness/kbin_federation_awareness.user.js
+++ b/mods/kbin_federation_awareness/kbin_federation_awareness.user.js
@@ -109,27 +109,19 @@ function initKFA (toggle) { // eslint-disable-line no-unused-vars
 
     function kfaStartup () {
         kfaInitClasses();
-        kfaInjectedCss = safeGM("addStyle",kfaGetCss());
+        safeGM("addStyle",kfaGetCss(),"kfaInjectedCss");
     }
 
     function kfaShutdown () {
-        if (kfaInjectedCss) {
-            kfaInjectedCss.remove();
-        }
-        function removeOld () {
-            for (let i = 0; i<arguments.length; ++i) {
-                arguments[i].forEach((el) => {
-                    el.remove();
-                });
-            }
-        }
-        const dh = document.querySelectorAll('header .data-home')
-        const df = document.querySelectorAll('header .data-federated')
-        const dm = document.querySelectorAll('header .data-moderated')
-        const mh = document.querySelectorAll('.meta.entry__meta .data-home')
-        const mf = document.querySelectorAll('.meta.entry__meta .data-federated')
-        const mm = document.querySelectorAll('.meta.entry__meta .data-moderated')
-        removeOld(dh, df, dm, mh, mf, mm);
+        safeGM("removeStyle","kfaInjectedCss");
+        document.querySelectorAll('div.data-home, div.data-federated, div.data-moderated')
+            .forEach((element) => element.remove());
+        document.querySelectorAll('.data-home')
+            .forEach((element) => element.classList.remove('data-home'));
+        document.querySelectorAll('.data-federated')
+            .forEach((element) => element.classList.remove('data-federated'));
+        document.querySelectorAll('.data-moderated')
+            .forEach((element) => element.classList.remove('data-moderated'));
     }
 
     function findHostname (op) {
@@ -194,7 +186,6 @@ function initKFA (toggle) { // eslint-disable-line no-unused-vars
         });
     }
 
-    let kfaInjectedCss;
     let kfaSettingsFed;
     let kfaSettingsMod;
     let kfaSettingsHome;
@@ -210,6 +201,7 @@ function initKFA (toggle) { // eslint-disable-line no-unused-vars
         kfaSettingsArticleSide = settings['kfaPostSide'];
         kfaSettingsStyle = settings['kfaStyle'];
         kfaSettingsScale = settings['kfaBubbleScale'];
+        kfaShutdown();
         kfaStartup();
     } else {
         kfaShutdown();


### PR DESCRIPTION
The mod didn't clean up its CSS properly, leading to two issues:

1. When switching between bubble and border mode, the previous setting wasn't disabled. You simply now get both of them until you reload the page.
2. Only the bubble got cleaned up properly when the mod was turned off. Turning off the mod didn't do anything about the border. Instead, it was removed the next time the mod was turned ON. And so it would alternate between showing the border or not showing it every time it was turned on.

I fixed thsoe two issues by overhauling the cleanup. It now actually makes use of `removeStyle`.