### PR TITLE
[FIX] Notification panel failed to load

### DIFF
--- a/mods/notifications_panel/notifications_panel.json
+++ b/mods/notifications_panel/notifications_panel.json
@@ -4,7 +4,7 @@
     "blobcat",
     "shazbot"
   ],
-  "version": "0.3.1",
+  "version": "0.3.2",
   "label": "Add a notifications panel",
   "login": true,
   "recurs": false,

--- a/mods/notifications_panel/notifications_panel.user.js
+++ b/mods/notifications_panel/notifications_panel.user.js
@@ -362,6 +362,13 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
         const iframe = document.createElement('div');
         iframe.className = 'notifications-iframe dropdown__menu';
         iframe.style.cssText = iframeCSS
+        iframe.addEventListener('click', () => {
+            if (iframe.querySelector('.noti-no-messages')) {
+                iframe.remove();
+                document.querySelector('.clickmodal').remove();
+                return;
+            }
+            });
 
         let loading = document.createElement('div')
         loading.className = "loadingmsg"

--- a/mods/notifications_panel/notifications_panel.user.js
+++ b/mods/notifications_panel/notifications_panel.user.js
@@ -199,8 +199,9 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
         let notificationsXML = parser.parseFromString(response.responseText, "text/html");
         const token = notificationsXML.querySelector('#push-subscription-div')
             .getAttribute('data-application-server-public-key');
-        let currentPage = notificationsXML.all[6].content.split('=')[1]
+        let currentPage = notificationsXML.querySelector('[property="og:url"]').content.split('=')[1]
         let currentPageInt = parseInt(currentPage)
+        // 2025-01-19: there can be 25 messages before pagination occurs
         let sects = notificationsXML.querySelectorAll('.notification');
         if (sects.length === 0) {
             loadingSpinner.remove();

--- a/mods/notifications_panel/notifications_panel.user.js
+++ b/mods/notifications_panel/notifications_panel.user.js
@@ -376,8 +376,10 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
             iframe.remove();
             clickModal.remove();
             safeGM("addStyle",resetDropdownCSS)
-        })
-        document.querySelector('.kbin-container').appendChild(clickModal)
+        });
+        const container = document.querySelector('.kbin-container') 
+            ?? document.querySelector('.mbin-container');
+        container.appendChild(clickModal);
         listItem.appendChild(iframe);
         genericXMLRequest(notificationsURL + '?p=1',insertMsgs);
     }
@@ -385,7 +387,8 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
     function build () {
         const notiPanel = document.querySelector('li.notification-button');
         if (notiPanel) return
-        const parentElement = document.querySelector('.header .kbin-container');
+        const parentElement = document.querySelector('.header .kbin-container')
+                ?? document.querySelector('.header .mbin-container');
         if (parentElement) {
             const listItem = document.createElement('li');
             listItem.classList.add('notification-button');

--- a/mods/notifications_panel/notifications_panel.user.js
+++ b/mods/notifications_panel/notifications_panel.user.js
@@ -197,10 +197,8 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
         let iff = document.querySelector('.notifications-iframe');
         let parser = new DOMParser();
         let notificationsXML = parser.parseFromString(response.responseText, "text/html");
-        const readTokenEl = notificationsXML.querySelector('.pills menu form[action="/settings/notifications/read"] input')
-        const readToken = readTokenEl.value
-        const purgeTokenEl = notificationsXML.querySelector('.pills menu form[action="/settings/notifications/clear"] input')
-        const purgeToken = purgeTokenEl.value
+        const token = notificationsXML.querySelector('#push-subscription-div')
+            .getAttribute('data-application-server-public-key');
         let currentPage = notificationsXML.all[6].content.split('=')[1]
         let currentPageInt = parseInt(currentPage)
         let sects = notificationsXML.querySelectorAll('.notification');
@@ -277,7 +275,7 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
             readButton.style.setProperty('--noti-button-opacity','0.7')
             readButton.addEventListener('click', () => {
                 clearPanel();
-                genericPOSTRequest(notificationsURL + '/read', readAndReset, readToken);
+                genericPOSTRequest(notificationsURL + '/read', readAndReset, token);
             });
         } else {
             readButton.style.opacity = 0.7;
@@ -285,7 +283,7 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
         }
         purgeButton.addEventListener('click', () => {
             clearPanel();
-            genericPOSTRequest(notificationsURL + '/clear', readAndReset, purgeToken);
+            genericPOSTRequest(notificationsURL + '/clear', readAndReset, token);
         });
 
         if (currentPageInt != 1) {


### PR DESCRIPTION
This mod had two issues.

1. The button for the notifications panel wasn't added. This was because of the `.mbin-container` change.
2. The contents didn't load, because the tokens for the mark as read and purge buttons weren't found and so an exception was thrown.

The two commits here fix those two issues.