### PR TITLE
[FIX] Omnibar meta key wasn't working

### DIFF
--- a/mods/omni/omni.json
+++ b/mods/omni/omni.json
@@ -1,7 +1,7 @@
 {
   "name": "Subs omnibar",
   "author": "shazbot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "label": "Subscriptions omnibar",
   "desc": "Quickly jump to a magazine by viewing your subs in a floating search panel (type to search). Use the meta key to open/close the omnibar. The meta key will not take effect inside of text fields. If you are logged out, the omnibar shows default magazines (most popular). To refresh the cached list of your magazines or change settings while this add-on is enabled, toggle off and then on again.",
   "login": false,

--- a/mods/omni/omni.json
+++ b/mods/omni/omni.json
@@ -13,7 +13,7 @@
       "type": "checkbox",
       "key": "mobile",
       "label": "Mobile device support",
-      "checkbox_label": "Add tappable element to screen"
+      "checkbox_label": "Add tappable element (yellow bar) to screen"
     },
     {
       "type": "radio",

--- a/mods/omni/omni.user.js
+++ b/mods/omni/omni.user.js
@@ -426,7 +426,8 @@ function omniInit (toggle) { // eslint-disable-line no-unused-vars
                 kt.focus()
             }
 
-            const pageHolder = document.querySelector('.kbin-container')
+            const pageHolder = document.querySelector('.kbin-container') 
+                ?? document.querySelector('.mbin-container')
             const kth = document.createElement('div');
             kth.style.cssText = 'height: 0px; width: 0px'
             const ktb = document.createElement('button')
@@ -436,6 +437,7 @@ function omniInit (toggle) { // eslint-disable-line no-unused-vars
             pageHolder.insertBefore(kth, pageHolder.children[0])
             ktb.addEventListener('keyup',kickoffListener)
             const globalKeyInsert = document.querySelector('[data-controller="kbin notifications"]')
+                ?? document.querySelector('[data-controller="mbin notifications"]');
             globalKeyInsert.addEventListener('keydown',keyTrap)
 
 


### PR DESCRIPTION
The omnibar's meta key option wasn't working because of the `.mbin-container` issue. Now it works again.