### PR TITLE
[FIX] resize_text mod didn't work fully

### DIFF
--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -1,7 +1,7 @@
 {
   "name": "Customize font size",
   "author": "minnieo",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "label": "Change font size",
   "login": false,
   "recurs": true,
@@ -115,15 +115,6 @@
       "initial": "div.page-messages",
       "key": "optionMessages",
       "label": "Inbox messages:",
-      "step": "0.1",
-      "min": "5",
-      "max": "50"
-    },
-    {
-      "type": "number",
-      "initial": "#footer > .kbin-container > section menu li",
-      "key": "optionFooter",
-      "label": "Footer:",
       "step": "0.1",
       "min": "5",
       "max": "50"

--- a/mods/resize_text/resize_text.json
+++ b/mods/resize_text/resize_text.json
@@ -5,7 +5,7 @@
   "label": "Change font size",
   "login": false,
   "recurs": true,
-  "desc": "Customize the font size site-wide. The window will become transparent as you increment/decrement font sizes. Note: reload required when toggling off.",
+  "desc": "Customize the font size site-wide. The window will become transparent as you increment/decrement font sizes.",
   "entrypoint": "resize_text",
   "namespace": "resize",
   "page": "accessibility",

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -44,6 +44,9 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
         .page-messages > .kbin-container > #main > h1 {
             font-size: ${settings["optionMessages"] * 2.5}px
         }
+        .page-messages > .mbin-container > #main > h1 {
+            font-size: ${settings["optionMessages"] * 2.5}px
+        }
         /* SIDEBAR */
         #sidebar * {
             font-size: ${settings["optionHomeSidebar"]}px !important

--- a/mods/resize_text/resize_text.user.js
+++ b/mods/resize_text/resize_text.user.js
@@ -98,16 +98,8 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${settings["optionUserSettings"] * 2.5}px
         }
         /* ============= */
-        /* FOOTER */
-        #footer > .kbin-container > section * {
-            font-size: ${settings["optionFooter"]}px
-        }
-        #footer > .kbin-container > section h5 {
-            font-size: ${settings["optionFooter"] * 1.222}px
-        }
-        /* ============= */
         /* SORT OPTIONS */
-        aside#options menu li a, aside#options menu i {
+        aside#options menu li a, aside#options menu i, aside#options menu button span {
             font-size: ${settings["optionSortBy"]}px
         }
         /* INBOX NOTIFICATIONS */
@@ -118,6 +110,15 @@ function textResize (toggle) { // eslint-disable-line no-unused-vars
             font-size: ${settings["optionNotifs"] * 0.85}px
         }
         .page-notifications > .kbin-container > main > h1 {
+            font-size: ${settings["optionNotifs"] * 2.5}px !important
+        }
+        .page-notifications > .mbin-container > main > * {
+            font-size: ${settings["optionNotifs"]}px
+        }
+        .page-notifications > .mbin-container > main > .pills > menu > form > button {
+            font-size: ${settings["optionNotifs"] * 0.85}px
+        }
+        .page-notifications > .mbin-container > main > h1 {
             font-size: ${settings["optionNotifs"] * 2.5}px !important
         }
         /* ============= */


### PR DESCRIPTION
Fixed a few issues with some of the options in this mod:

- The description claimed a reload would be required to turn the mod off, but that wasn't the case for me at all.
- The footer option didn't work because Mbin moved its "footer" to the sidebar where it's affected by the regular sidebar option. So I removed the option.
- The sort by option only applied to the icons in the sort bar, not the actual text.
- The notifications and the messages title were suffering from the `.mbin-container` issue.