### PR TITLE
[FEAT] Simplified toggling the thread_checkmarks mod

### DIFF
--- a/mods/omni/omni.json
+++ b/mods/omni/omni.json
@@ -30,5 +30,8 @@
       ]
     }
   ],
-  "page": "general"
+  "page": "general",
+  "depends_off": [
+    "thread_checkmarks"
+  ]
 }

--- a/mods/thread_checkmarks/thread_checkmarks.json
+++ b/mods/thread_checkmarks/thread_checkmarks.json
@@ -3,7 +3,7 @@
   "author": "shazbot",
   "version": "0.1.0",
   "label": "Checkmark on subbed mags",
-  "desc": "Append a checkmark to magazines on the thread index you are subscribed to. The 'Subscriptions omnibar' option (page: General) must be enabled for this to work",
+  "desc": "Append a checkmark to magazines on the thread index you are subscribed to.",
   "login": false,
   "recurs": true,
   "entrypoint": "thread_checkmarks",
@@ -16,5 +16,8 @@
       "initial": "--kbin-upvoted-color"
     }
   ],
-  "page": "threads"
+  "page": "threads",
+  "depends_on": [
+    "omni"
+  ]
 }


### PR DESCRIPTION
The thread_checkmarks mod was missing the depends_on (and depends_off for omni) property, so I added them both. Now the user shouldn't have to manually go look for the omnibar mod anymore.