### PR TITLE
[FEAT] add logger

### DIFF
--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -23,6 +23,14 @@ try {
     console.log(error);
 }
 
+function log(string){
+    const date = new Date()
+    const iso = date.toISOString()
+    const caller = (new Error()).stack?.split("\n")[1].split("@")[0]
+    const line = `[KES:${caller}] [${iso}] ${string}`
+    console.log(line)
+}
+
 function addCustomCSS (css, id) {
     const style = document.createElement('style');
     style.id = id;


### PR DESCRIPTION
Adds a logger to provide more flexibility to scripts to  print meaningful info to the console.

Called as `log("some string")` and outputs as `[KES:callingFunction] [ISO8601 timestamp] some string`