### PR TITLE
fix: timestamps

### DIFF
--- a/kes.user.js
+++ b/kes.user.js
@@ -1399,17 +1399,23 @@ function constructMenu (json, layoutArr, isNew) {
                 }
                 return
             }
+            //trigger when username popover dialog is spawned on hover
+            //there can only be one popover spawned at a given time
+            if (mutation.target.id === "popover"){
+                applySettings("timestamp");
+                return
+            }
+            //workaround for timeago ticks changing timestamp textContent
+            //implies that the active 60s timestamp is updating
+            //see also updateState()
             if (mutation.target.className === 'timeago') {
-                //workaround for timeago ticks changing timestamp textContent
-                //implies that the active 60s timestamp is updating
-                //reapplies verbose timestamps
-                //see also updateState()
                 if (mutation.target.textContent.indexOf("ago") >= 0) {
                     applySettings("timestamp");
                 }
                 //triggering on the first mutation is sufficient to apply to all timestamps
                 return
-            } else if ((mutation.target.getAttribute("data-controller") == "subject-list") || (mutation.target.id == "comments")) {
+            }
+            if ((mutation.target.getAttribute("data-controller") == "subject-list") || (mutation.target.id == "comments")) {
                 //implies that a recurring/infinite scroll event like new threads or comment creation occurred
                 for (let i = 0; i < json.length; ++i) {
                     if (json[i].recurs) {

--- a/kes.user.js
+++ b/kes.user.js
@@ -1236,13 +1236,7 @@ function constructMenu (json, layoutArr, isNew) {
         saveModSettings(modSettings, ns);
 
         updateCrumbs();
-        //necessarily reload the page when verbose timestamps are toggled off
-        //otherwise, triggers a loop of mutations because reverting timeago mutates watched node
-        if ((func === "timestamp") && (state === false)) {
-            window.location.reload();
-        } else {
-            toggleSettings(func);
-        }
+        toggleSettings(func);
     }
 
     function toggleDependencies (entry, state) {

--- a/kes.user.js
+++ b/kes.user.js
@@ -1409,7 +1409,7 @@ function constructMenu (json, layoutArr, isNew) {
             //implies that the active 60s timestamp is updating
             //see also updateState()
             if (mutation.target.className === 'timeago') {
-                if (mutation.target.textContent.indexOf("ago") >= 0) {
+                if (!mutation.target.classList.contains("hidden-timeago")) {
                     applySettings("timestamp");
                 }
                 //triggering on the first mutation is sufficient to apply to all timestamps

--- a/mods/timestamp/timestamp.user.js
+++ b/mods/timestamp/timestamp.user.js
@@ -16,7 +16,7 @@ function updateTime (toggle) { // eslint-disable-line no-unused-vars
     function cleanTime (time) {
         const iso = time.getAttribute('datetime');
         const isoYear = (iso.split('T')[0]);
-        const isoTime = (iso.split('T')[1]);
+        let isoTime = (iso.split('T')[1]);
         isoTime = (isoTime.split('+')[0]);
         const utcTime = isoYear + " @ " + isoTime;
         const localTime = new Date(iso);

--- a/mods/timestamp/timestamp.user.js
+++ b/mods/timestamp/timestamp.user.js
@@ -1,35 +1,76 @@
 function updateTime (toggle) { // eslint-disable-line no-unused-vars
-    const ns = 'timestamp'
-    let times = document.querySelectorAll('.timeago')
+
+    function teardown () {
+        times.forEach((time) => {
+            if (time.classList.contains(class_hidden)) {
+                time.classList.remove(class_hidden);
+                time.style.display = "initial";
+            }
+        })
+        const isoTimes = document.querySelectorAll("." + class_iso);
+        isoTimes.forEach((isoTime) => {
+            isoTime.remove();
+        })
+    }
+
+    function cleanTime (time) {
+        const iso = time.getAttribute('datetime');
+        const isoYear = (iso.split('T')[0]);
+        const isoTime = (iso.split('T')[1]);
+        isoTime = (isoTime.split('+')[0]);
+        const utcTime = isoYear + " @ " + isoTime;
+        const localTime = new Date(iso);
+        const localAsISO = localTime.toLocaleString('sv').replace(' ', ' @ ');
+        return [utcTime, localAsISO]
+    }
+
+    function updateSibling (el) {
+        const sibling = el.nextElementSibling;
+        const variant = sibling.dataset.timeVariant;
+        const cleanedTime = cleanTime(el);
+        if (settings["offset"] != variant){
+            setTime(sibling, cleanedTime);
+        }
+    }
+
+    function setTime (el, time) {
+        switch (settings["offset"]) {
+            case "UTC":
+                el.innerText = time[0];
+                el.dataset.timeVariant = "UTC";
+                break;
+            case "Local time":
+                el.innerText = time[1];
+                el.dataset.timeVariant = "Local time";
+                break;
+            default:
+                break;
+        }
+    }
+
+    const ns = 'timestamp';
+    const class_timeago = "timeago"
+    const class_hidden = "hidden-timeago"
+    const class_iso = "iso-timeago"
     const settings = getModSettings(ns);
+    const times = document.querySelectorAll("." + class_timeago);
+
     if (toggle) {
         times.forEach((time) => {
-            if (time.innerText === "just now") {
+            if (time.classList.contains(class_hidden)) {
+                //update time variant in case user changed preference while mod is on
+                updateSibling(time);
                 return
             }
-            if (time.innerText.indexOf("seconds") > -1) {
-                return
-            }
-            let iso = time.getAttribute('datetime');
-            let isoYear = (iso.split('T')[0]);
-            let isoTime = (iso.split('T')[1]);
-            isoTime = (isoTime.split('+')[0]);
-            let cleanISOTime = isoYear + " @ " + isoTime;
-            let localTime = new Date(iso);
-            let localAsISO = localTime.toLocaleString('sv').replace(' ', ' @ ');
-            let offset = "offset";
-            switch (settings[offset]) {
-                case "UTC":
-                    time.innerText = cleanISOTime;
-                    break;
-                case "Local time":
-                    time.innerText = localAsISO;
-                    break;
-                default:
-                    break;
-            }
+            const clone = time.cloneNode(false);
+            clone.className = class_iso;
+            time.insertAdjacentElement("afterend", clone);
+            time.style.display = "none";
+            time.classList.add(class_hidden);
+            cleanedTime = cleanTime(time);
+            setTime(clone, cleanedTime);
         });
     } else {
-        return
+        teardown();
     }
 }


### PR DESCRIPTION
Resolves multiple issues brought up in https://github.com/aclist/kbin-kes/issues/354:

- Mod required hard reload for teardown

The mod now makes a clone of the `timeago` elements and hides the original ones. On teardown, the clones are cleared and the original elements are made visible again. Their human readable timestamps continued updating in the background, so on teardown, the relative time delta is still accurate.

- Unnecessary recursion

Increments to the `timeago-id` parameter of `timeago` elements are silently ignored, and if a `timeago` element has already been cloned, the clone action is not propagated again.

- Update UTC/local time variant in place

If the user has changed their time setting preference while the mod is already on, the mod recursively updates existing timestamps to their corresponding variant (UTC<->local). The time variant is stored inside the dataset attribute `data-time-variant` and matches the corresponding value in the localStorage.

- Special exclusion inside of MES for this mod

Dropped requirement for MES to perform additional handling for the timestamps mod.