### PR TITLE
feat(hide_sidebar): option to hide the subs panel

### DIFF
--- a/mods/hide_sidebar/hide_sidebar.json
+++ b/mods/hide_sidebar/hide_sidebar.json
@@ -17,6 +17,11 @@
       "checkbox_label": "Hide sidebar entirely"
     },
     {
+      "key": "subs",
+      "type": "checkbox",
+      "checkbox_label": "Subscriptions"
+    },
+    {
       "key": "mags",
       "type": "checkbox",
       "checkbox_label": "Random mags"

--- a/mods/hide_sidebar/hide_sidebar.user.js
+++ b/mods/hide_sidebar/hide_sidebar.user.js
@@ -7,7 +7,8 @@ function hideSidebar (toggle) { // eslint-disable-line no-unused-vars
         posts: '#sidebar > .posts',
         threads: '#sidebar > .entries',
         instance: '#sidebar > .kbin-promo',
-        intro: '.sidebar-options > .intro'
+        intro: '.sidebar-options > .intro',
+        subs: '#sidebar > .sidebar-subscriptions'
     }
 
     const settings = getModSettings('hide-sidebar');


### PR DESCRIPTION
Adds an option to the `hide_sidebar` mod which allows hiding the subscription panel in the sidebar. While a native option to do this already exists, that one removes the panel entirely. This one simply hides it (like the other options in the mod), making the actual list still available for other functions and scripts to use.