### PR TITLE
feat(hide_sidebar): expand content when sidebar is hidden

### DIFF
--- a/mods/hide_sidebar/hide_sidebar.json
+++ b/mods/hide_sidebar/hide_sidebar.json
@@ -1,7 +1,7 @@
 {
   "name": "Hide sidebar",
   "author": "shazbot",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "label": "Hide sidebar elements",
   "login": false,
   "recurs": true,
@@ -45,6 +45,12 @@
       "key": "intro",
       "type": "checkbox",
       "checkbox_label": "Explore the fediverse intro text"
+    },
+    {
+      "label": "Behavior",
+      "key": "expand",
+      "type": "checkbox",
+      "checkbox_label": "Expand content if possible"
     }
   ]
 }

--- a/mods/hide_sidebar/hide_sidebar.user.js
+++ b/mods/hide_sidebar/hide_sidebar.user.js
@@ -23,10 +23,23 @@ function hideSidebar (toggle) { // eslint-disable-line no-unused-vars
                 $(obj[key]).show();
             }
         }
+        // expand the content to cover the space freed up by hiding the sidebar
+        const main = document.querySelector('.mbin-container > #main');
+        if (settings["sidebar"] && settings["expand"]) {
+            main.style.gridColumn = "span 2";
+        } else {
+            if (main.style.gridColumn == "span 2") {
+                main.style.gridColumn = '';
+            }
+        }
     } else {
         for (let i = 0; i< keys.length; i++) {
             let key = keys[i]
             $(obj[key]).show();
+        }
+        const main = document.querySelector('.mbin-container > #main');
+        if (main.style.gridColumn == "span 2") {
+            main.style.gridColumn = '';
         }
     }
 }


### PR DESCRIPTION
When the entire sidebar is hidden, the space it occupied is still left empty. This PR adds an option to have the main content expand to make use of the freed up space.