### PR TITLE
feat: more robust page enumeration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,9 @@
         "GM_getValue": "readonly",
         "GM_getResourceText": "readonly",
         "GM_setClipboard": "readonly",
-        "GM_xmlhttpRequest": "readonly"
+        "GM_xmlhttpRequest": "readonly",
+        "Mbin": "readonly",
+        "getPageType": "readonly"
     },
     "env": {
         "browser": true,

--- a/build/scripts/gen_kes.sh
+++ b/build/scripts/gen_kes.sh
@@ -52,6 +52,7 @@ gen_requires(){
     deps=(
         "safegm.user.js"
         "funcs.js"
+        "pages.js"
     )
     external=(
         "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"

--- a/docs/page_enums
+++ b/docs/page_enums
@@ -1,0 +1,31 @@
+Mbin.Top: 1,
+Mbin.Search: 2,
+Mbin.Magazines: 3,
+Mbin.People: 4,
+Mbin.Bookmarks: 5,
+Mbin.Tag: 6,
+Mbin.Microblog: 7,
+Mbin.Settings: 8,
+Mbin.Magazine: 9,
+
+Mbin.Messages.Inbox: 1
+Mbin.Messages.Notifications: 2
+Mbin.Messages.Thread: 3
+
+Mbin.User.Default: 1
+Mbin.User.DirectMessage: 2,
+Mbin.User.Subscriptions: 3,
+Mbin.User.Threads: 4,
+Mbin.User.Comments: 5,
+Mbin.User.Posts: 6,
+Mbin.User.Replies: 7,
+Mbin.User.Boosts: 8,
+Mbin.User.Following: 9,
+Mbin.User.Followers: 10
+
+Mbin.Thread.Comments: 1,
+Mbin.Thread.Favorites: 2,
+Mbin.Thread.Boosts: 3,
+
+Mbin.Domain.Default:1
+Mbin.Domain.Comments:2

--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -83,50 +83,50 @@ function getPageType () { //eslint-disable-line no-unused-vars
         case "sub":
         case "all":
         case "threads":
-            return "Mbin.Top"
+            return Mbin.Top
         case "search":
-            return "Mbin.Search"
+            return Mbin.Search
         case "magazines":
-            return "Mbin.Magazines"
+            return Mbin.Magazines
         case "people":
-            return "Mbin.People"
+            return Mbin.People
         case "bookmark-lists":
-            return "Mbin.Bookmarks"
+            return Mbin.Bookmarks
         case "tag":
-            return "Mbin.Tag"
+            return Mbin.Tag
         case "microblog":
-            return "Mbin.Microblog"
+            return Mbin.Microblog
         case "profile":
             if ((url[4] === "messages") && (url.length === 6)) return "Mbin.Messages.Thread"
-            return "Mbin.Messages.Inbox"
+            return Mbin.Messages.Inbox
         case "settings":
             if ((url[4]) === "notifications") return "Mbin.Messages.Notifications"
-            return "Mbin.Settings"
+            return Mbin.Settings
         case "u":
-            if (url[5] === undefined) return "Mbin.User"
-            if (url[5] === "message") return "Mbin.User.Direct_Message"
-            if (url[5].includes("subscriptions")) return "Mbin.User.Subscriptions"
-            if (url[5].includes("threads")) return "Mbin.User.Threads"
-            if (url[5].includes("comments")) return "Mbin.User.Comments"
-            if (url[5].includes("posts")) return "Mbin.User.Posts"
-            if (url[5].includes("replies")) return "Mbin.User.Replies"
-            if (url[5].includes("boosts")) return "Mbin.User.Boosts"
-            if (url[5].includes("following")) return "Mbin.User.Following"
-            if (url[5].includes("followers")) return "Mbin.User.Followers"
-            return "Mbin.User"
+            if (url[5] === undefined) return Mbin.User.Default
+            if (url[5] === "message") return Mbin.User.DirectMessage
+            if (url[5].includes("subscriptions")) return Mbin.User.Subscriptions
+            if (url[5].includes("threads")) return Mbin.User.Threads
+            if (url[5].includes("comments")) return Mbin.User.Comments
+            if (url[5].includes("posts")) return Mbin.User.Posts
+            if (url[5].includes("replies")) return Mbin.User.Replies
+            if (url[5].includes("boosts")) return Mbin.User.Boosts
+            if (url[5].includes("following")) return Mbin.User.Following
+            if (url[5].includes("followers")) return Mbin.User.Followers
+            return Mbin.User.Default
         case "d":
-            if ((url.length === 6) && (url[5].includes("comments"))) return "Mbin.Domain.Comments"
-            return "Mbin.Domain"
+            if ((url.length === 6) && (url[5].includes("comments"))) return Mbin.Domain.Comments
+            return Mbin.Domain.Default
         case "m":
-            if (url[5] === undefined) return "Mbin.Magazine"
-            if (url[5] === "microblog") return "Mbin.Microblog"
-            if ((url[5] === "t") && (url[url.length-1].includes("favourites"))) return "Mbin.Thread.Favorites"
-            if ((url[5] === "t") && (url[url.length-1].includes("up"))) return "Mbin.Thread.Boosts"
-            return "Mbin.Thread.Comments"
+            if (url[5] === undefined) return Mbin.Magazine
+            if (url[5] === "microblog") return Mbin.Microblog
+            if ((url[5] === "t") && (url[url.length-1].includes("favourites"))) return Mbin.Thread.Favorites
+            if ((url[5] === "t") && (url[url.length-1].includes("up"))) return Mbin.Thread.Boosts
+            return Mbin.Thread.Comments
         default:
             break;
     }
-    if (url[3].includes("?type=")) return "Mbin.Top"
+    if (url[3].includes("?type=")) return Mbin.Top
     return "Unknown"
 }
 

--- a/mods/alpha_sort_subs/alpha_sort_subs.user.js
+++ b/mods/alpha_sort_subs/alpha_sort_subs.user.js
@@ -8,7 +8,7 @@ function alphaSortInit (toggle) { // eslint-disable-line no-unused-vars
         return _getMagName(a) > _getMagName(b) ? 1: -1
     }
 
-    const pt = getPageType(); // eslint-disable-line no-undef
+    const pt = getPageType();
     let list_columns
     switch (pt) {
         case Mbin.User.Subscriptions: {

--- a/mods/alpha_sort_subs/alpha_sort_subs.user.js
+++ b/mods/alpha_sort_subs/alpha_sort_subs.user.js
@@ -11,12 +11,12 @@ function alphaSortInit (toggle) { // eslint-disable-line no-unused-vars
     const pt = getPageType(); // eslint-disable-line no-undef
     let list_columns
     switch (pt) {
-        case "Mbin.User.Subscriptions": {
+        case Mbin.User.Subscriptions: {
             list_columns = '.magazines-columns'
             break;
         }
-        case "Mbin.User.Followers":
-        case "Mbin.User.Following": {
+        case Mbin.User.Followers:
+        case Mbin.User.Following: {
             list_columns = '.users-columns'
             break;
         }

--- a/mods/clarify_recipient/clarify_recipient.user.js
+++ b/mods/clarify_recipient/clarify_recipient.user.js
@@ -21,7 +21,7 @@ function clarifyRecipientInit (toggle) { // eslint-disable-line no-unused-vars
     }
 
     const pt = getPageType(); // eslint-disable-line no-undef
-    if (pt !== "Mbin.User.Direct_Message") return
+    if (pt !== Mbin.User.DirectMessage) return
     const form = document.querySelector('form[name="message"]')
     if (!form) return
     if (toggle) {

--- a/mods/kbin_federation_awareness/kbin_federation_awareness.user.js
+++ b/mods/kbin_federation_awareness/kbin_federation_awareness.user.js
@@ -197,7 +197,7 @@ function initKFA (toggle) { // eslint-disable-line no-unused-vars
 
     function kfaInitClasses () {
         const page = getPageType(); // eslint-disable-line no-undef
-        if (page === "Mbin.Microblog") {
+        if (page === Mbin.Microblog) {
             document.querySelectorAll('.section.post.subject').forEach(function (comment) {
                 if (comment.querySelector('[class^=data-]')) { return }
                 prependToComment(comment);
@@ -208,7 +208,7 @@ function initKFA (toggle) { // eslint-disable-line no-unused-vars
             });
             return
         }
-        if (page !== "Mbin.Microblog") {
+        if (page !== Mbin.Microblog) {
             document.querySelectorAll('#content article.entry:not(.entry-cross)').forEach(function (article) {
                 if (article.querySelector('[class^=data-]')) { return }
                 let op = article.querySelector('.user-inline').href

--- a/mods/user_instance_names/user_instance_names.user.js
+++ b/mods/user_instance_names/user_instance_names.user.js
@@ -27,12 +27,12 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
         const page = getPageType() //eslint-disable-line no-undef
         let el
         switch (page) {
-            case "Mbin.Thread.Favorites":
-            case "Mbin.User.Followers":
-            case "Mbin.User.Following":
+            case Mbin.Thread.Favorites:
+            case Mbin.User.Followers:
+            case Mbin.User.Following:
                 el = ".users-columns .stretched-link"
                 break;
-            case "Mbin.User":
+            case Mbin.User.Default:
                 el = ".user-inline"
                 break;
             default:


### PR DESCRIPTION
This updates `getPageType()` to return more traditional namespaced object enumerations instead of raw strings. These can be accessed under the global `Mbin` namespace, with the suffixes below.

Enums are uniquely indexed within the sub-domains, so there should not be collisions.

A placeholder for this documentation has been put in `docs/page_enums`.
Additionally, `getPageType()` and `Mbin` were added to the global ESLint exclusions, so mods do not have to add per-line exclusions when calling these.

Mods can use this logic by checking the return value of `getPageType()` against the desired page, e.g., 

Old:
```
if (getPageType() === "Mbin.Domain.Comments") {
   take some action
}
```

New:

```
if (getPageType() === Mbin.Domain.Comments) {
   take some action
}
```

General
---
Mbin.Top: 1,
Mbin.Search: 2,
Mbin.Magazines: 3,
Mbin.People: 4,
Mbin.Bookmarks: 5,
Mbin.Tag: 6,
Mbin.Microblog: 7,
Mbin.Settings: 8,
Mbin.Magazine: 9

Mbin.Messages
---
Mbin.Messages.Inbox: 1
Mbin.Messages.Notifications: 2
Mbin.Messages.Thread: 3

Mbin.User
---
Mbin.User.Default: 1
Mbin.User.DirectMessage: 2,
Mbin.User.Subscriptions: 3,
Mbin.User.Threads: 4,
Mbin.User.Comments: 5,
Mbin.User.Posts: 6,
Mbin.User.Replies: 7,
Mbin.User.Boosts: 8,
Mbin.User.Following: 9,
Mbin.User.Followers: 10

Mbin.Thread
---
Mbin.Thread.Comments: 1,
Mbin.Thread.Favorites: 2,
Mbin.Thread.Boosts: 3

Mbin.Domain
---
Mbin.Domain.Default: 1
Mbin.Domain.Comments: 2