### PR TITLE
fix: readable header styling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -21,7 +21,9 @@
         "GM_setClipboard": "readonly",
         "GM_xmlhttpRequest": "readonly",
         "Mbin": "readonly",
-        "getPageType": "readonly"
+        "getPageType": "readonly",
+        "isLoggedIn": "readonly",
+        "log": "readonly"
     },
     "env": {
         "browser": true,

--- a/mods/notifications_panel/notifications_panel.user.js
+++ b/mods/notifications_panel/notifications_panel.user.js
@@ -103,17 +103,20 @@ function notificationsPanel (toggle) { // eslint-disable-line no-unused-vars
         margin: 0 5px;
     }
     .noti-panel-header {
-        background: var(--kbin-button-primary-bg);
+        background: var(--kbin-sidebar-settings-switch-off-bg);
         display: flex;
         padding: 5px;
     }
+
     .noti-arrow-holder {
         margin-left: auto
     }
     .noti-read, .noti-purge {
-        background: var(--kbin-button-secondary-hover-bg);
         margin-left: 7px;
+        background: var(--kbin-sidebar-settings-switch-on-bg);
+        color: var(--kbin-sidebar-settings-switch-on-color);
     }
+
     .noti-read,.noti-purge,.noti-back,.noti-forward {
         padding: 5px;
         cursor: pointer;


### PR DESCRIPTION
Updates the notification panel mod's button and header styling by using more readable internal Mbin theme variables that follow the look of buttons in the sidebar. Resolves https://github.com/aclist/kbin-kes/issues/414