### PR TITLE
fix (hide thumbs): apply on microblogs

### DIFF
--- a/mods/hide_thumbs/hide_thumbs.json
+++ b/mods/hide_thumbs/hide_thumbs.json
@@ -5,20 +5,7 @@
   "label": "Hide thumbnails",
   "login": false,
   "recurs": true,
-  "desc": "Hide thumbnails on threads and comments",
+  "desc": "Hide inline thumbnails on threads. For thumbnails on the thread index, use Mbin's native setting.",
   "entrypoint": "hide_thumbs",
-  "page": "general",
-  "namespace": "hidethumbs",
-  "fields": [
-    {
-      "type": "checkbox",
-      "key": "index",
-      "checkbox_label": "Hide on thread index"
-    },
-    {
-      "type": "checkbox",
-      "key": "inline",
-      "checkbox_label": "Hide inline thumbnails"
-    }
-  ]
+  "page": "general"
 }

--- a/mods/hide_thumbs/hide_thumbs.json
+++ b/mods/hide_thumbs/hide_thumbs.json
@@ -2,10 +2,10 @@
   "name": "Hide thumbnails",
   "author": "shazbot",
   "version": "0.1.0",
-  "label": "Hide thumbnails",
+  "label": "Hide thumbnails on microblogs",
   "login": false,
   "recurs": true,
-  "desc": "Hide inline thumbnails on threads. For thumbnails on the thread index, use Mbin's native setting.",
+  "desc": "Hide inline thumbnails on microblogs. For thumbnails on the thread index, use Mbin's native setting.",
   "entrypoint": "hide_thumbs",
   "page": "general"
 }

--- a/mods/hide_thumbs/hide_thumbs.user.js
+++ b/mods/hide_thumbs/hide_thumbs.user.js
@@ -1,37 +1,38 @@
 function hideThumbs (toggle) { //eslint-disable-line no-unused-vars
-    const settings = getModSettings('hidethumbs')
-    const index = 'kes-index-thumbs'
-    const inline = 'kes-inline-thumbs'
-    const thumbsCSS = `
-    .entry.section.subject figure, .no-image-placeholder {
-        display: none
+    function show () {
+        log("trying to show thumbnails", Log.Log)
+        document.querySelectorAll(".figure-container").forEach((container) => {
+            if (container.dataset.hidden === "true") {
+                container.style.removeProperty("display");
+                delete container.dataset.hidden
+            }
+        });
+        document.querySelectorAll(".mes-thumbs-hide").forEach((icon) => {
+            icon.remove();
+        });
     }
-    `
-    const inlineCSS = `
-    .thumbs {
-        display:none
+
+    function hide () {
+        document.querySelectorAll('.figure-container').forEach((container) => {
+            if (container.dataset.hidden === "true") return
+            container.dataset.hidden = "true"
+
+            const prev = document.createElement('i')
+            prev.classList.add("mes-thumbs-hide", "fas", "fa-photo-video");
+            prev.ariaLabel = "Expand/collapse this image"
+            prev.addEventListener("click", () => {
+                if (container.style.display === "none") {
+                    container.style.removeProperty("display");
+                } else {
+                    container.style.display = "none"
+                }
+            });
+
+            container.insertAdjacentElement("beforebegin", prev);
+            container.style.display = "none"
+        })
     }
-    `
-    function apply (sheet, name) {
-        unset(name)
-        safeGM("addStyle", sheet, name)
-    }
-    function unset (name) {
-        safeGM("removeStyle", name)
-    }
-    if (toggle) {
-        if (settings["index"]) {
-            apply(thumbsCSS, index);
-        } else {
-            unset(index)
-        }
-        if (settings["inline"]) {
-            apply(inlineCSS, inline)
-        } else {
-            unset(inline)
-        }
-    } else {
-        unset(index)
-        unset(inline)
-    }
+
+    if (toggle) hide();
+    if (!toggle) show();
 }

--- a/mods/hide_thumbs/hide_thumbs.user.js
+++ b/mods/hide_thumbs/hide_thumbs.user.js
@@ -1,6 +1,5 @@
 function hideThumbs (toggle) { //eslint-disable-line no-unused-vars
     function show () {
-        log("trying to show thumbnails", Log.Log)
         document.querySelectorAll(".figure-container").forEach((container) => {
             if (container.dataset.hidden === "true") {
                 container.style.removeProperty("display");


### PR DESCRIPTION
Resolves #394

Wraps raw inline thumbnails on microblogs with an image icon that can be used to toggle expand/hide. For thumbnails in threads and on the thread index, the user should prefer using the inbuilt settings sidebar.