### PR TITLE
fix (hide_logo) Add padding and support mbin logo

### DIFF
--- a/mods/hide_logo/hide_logo.json
+++ b/mods/hide_logo/hide_logo.json
@@ -17,6 +17,8 @@
       "key": "logotype",
       "values": [
         "Hidden",
+        "Mbin",
+        "Mbin (no text)",
         "Kbin (no text)",
         "Kibby",
         "Kibby (no text)"

--- a/mods/hide_logo/hide_logo.user.js
+++ b/mods/hide_logo/hide_logo.user.js
@@ -3,6 +3,16 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
     const kibby = `${prefix}/kbin_logo_kibby.svg`
     const kibbyMini = `${prefix}/kibby-mini.svg`
     const kbinMini = `${prefix}/kbin-mini.svg`
+    const mbinNoText = "https://raw.githubusercontent.com/MbinOrg/mbin/refs/heads/main/assets/images/sources/mbin-notext.svg"
+    const mbin = "https://raw.githubusercontent.com/MbinOrg/mbin/refs/heads/main/assets/images/sources/mbin-logo.svg"
+
+    const logos = {
+        "Kbin (no text)": kbinMini,
+        "Kibby": kibby,
+        "Kibby (no text)": kibbyMini,
+        "Mbin (no text)": mbinNoText,
+        "Mbin": mbin
+    }
 
     function getDefaultLogo () {
         const keyw = document.querySelector('meta[name="keywords"]').content.split(',')[0]
@@ -12,34 +22,46 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
 
     function updateLogo (link) {
         $('.brand a').show();
+        document.querySelector(".head-nav__menu").style.removeProperty("padding-left")
         const img = document.querySelector('.brand a img');
-        img.setAttribute("src", link);
+        //special handling for instances with text-only logo
+        if (!img) {
+            const sp = document.querySelector(".brand a span")
+            sp.style.display = "none"
+            const i = document.createElement("img");
+            i.setAttribute("src", link)
+            i.id = "logo"
+            sp.insertAdjacentElement("afterend", i)
+
+        } else {
+            img.setAttribute("src", link);
+        }
     }
 
     function changeLogo () {
         const ns = "changelogo";
-
         const settings = getModSettings(ns);
         let opt = settings["logotype"];
         switch (opt) {
             case "Hidden":
                 updateLogo(getDefaultLogo())
                 $('.brand a').hide();
+                document.querySelector(".head-nav__menu").style.paddingLeft = "20px"
                 break;
-            case "Kibby":
-                updateLogo(kibby);
-                break;
-            case "Kbin (no text)":
-                updateLogo(kbinMini);
-                break;
-            case "Kibby (no text)":
-                updateLogo(kibbyMini);
-                break;
+            default:
+                updateLogo(logos[opt])
         }
     }
 
     function restoreLogo () {
         $('.brand').show();
+        //special handling for instances with text-only logo
+        const sp = document.querySelector(".brand a span");
+        if (sp) {
+            sp.style.removeProperty("display");
+            document.querySelector(".brand a img").remove();
+            return
+        }
         updateLogo(getDefaultLogo());
 
     }

--- a/mods/hide_logo/hide_logo.user.js
+++ b/mods/hide_logo/hide_logo.user.js
@@ -32,7 +32,6 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
             i.setAttribute("src", link)
             i.id = "logo"
             sp.insertAdjacentElement("afterend", i)
-
         } else {
             img.setAttribute("src", link);
         }
@@ -63,7 +62,6 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
             return
         }
         updateLogo(getDefaultLogo());
-
     }
 
     if (toggle) {

--- a/mods/hide_logo/hide_logo.user.js
+++ b/mods/hide_logo/hide_logo.user.js
@@ -56,8 +56,10 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
         $('.brand').show();
         //special handling for instances with text-only logo
         const sp = document.querySelector(".brand a span");
+        const a = document.querySelector(".brand a");
         if (sp) {
             sp.style.removeProperty("display");
+            a.style.removeProperty("display");
             document.querySelector(".brand a img").remove();
             return
         }


### PR DESCRIPTION
Resolves #351, #392

- Add padding to magazine name when logo is empty
- Add Mbin logo (text and no-text versions)
- Support instances like fedia where there is no img and just a text span