### PR TITLE
feat (hide related): hide related/crossposts area

### DIFF
--- a/mods/hide_related/hide_related.js
+++ b/mods/hide_related/hide_related.js
@@ -2,12 +2,10 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
 
     function isIndex () {
         const pt = getPageType();
-        log(isIndex, Log.Log)
         switch (pt) {
             case Mbin.Domain.Default:
             case Mbin.Domain.Comments:
             case Mbin.Top:
-                log("found index", Log.Log)
                 return true
             default:
                 return false
@@ -27,7 +25,7 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
 
     function hideRelated () {
         restoreRelated();
-        const settings = getModSettings("hide_related")
+        const settings = getModSettings("hide_related");
         if ((settings["index"]) && (isIndex())) {
             document.querySelectorAll(".entry-cross").forEach((entry) => {
                 entry.style.display = "none"
@@ -42,10 +40,10 @@ function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
 
     function restoreRelated () {
         document.querySelectorAll(".entry-cross").forEach((entry) => {
-            entry.style.removeProperty("display")
+            entry.style.removeProperty("display");
         })
         document.querySelectorAll(".entries-cross").forEach((entry) => {
-            entry.style.removeProperty("display")
+            entry.style.removeProperty("display");
         })
     }
 

--- a/mods/hide_related/hide_related.js
+++ b/mods/hide_related/hide_related.js
@@ -1,0 +1,54 @@
+function toggleLogo (toggle) { // eslint-disable-line no-unused-vars
+
+    function isIndex () {
+        const pt = getPageType();
+        log(isIndex, Log.Log)
+        switch (pt) {
+            case Mbin.Domain.Default:
+            case Mbin.Domain.Comments:
+            case Mbin.Top:
+                log("found index", Log.Log)
+                return true
+            default:
+                return false
+        }
+    }
+    function isThread () {
+        const pt = getPageType();
+        switch (pt) {
+            case Mbin.Thread.Comments:
+            case Mbin.Thread.Favorites:
+            case Mbin.Thread.Boosts:
+                return true
+            default:
+                return false
+        }
+    }
+
+    function hideRelated () {
+        restoreRelated();
+        const settings = getModSettings("hide_related")
+        if ((settings["index"]) && (isIndex())) {
+            document.querySelectorAll(".entry-cross").forEach((entry) => {
+                entry.style.display = "none"
+            })
+        }
+        if ((settings["thread"]) && (isThread())) {
+            document.querySelectorAll(".entries-cross").forEach((entry) => {
+                entry.style.display = "none"
+            });
+        }
+    }
+
+    function restoreRelated () {
+        document.querySelectorAll(".entry-cross").forEach((entry) => {
+            entry.style.removeProperty("display")
+        })
+        document.querySelectorAll(".entries-cross").forEach((entry) => {
+            entry.style.removeProperty("display")
+        })
+    }
+
+    if (toggle) hideRelated();
+    if (!toggle) restoreRelated();
+}

--- a/mods/hide_related/hide_related.json
+++ b/mods/hide_related/hide_related.json
@@ -1,0 +1,24 @@
+{
+  "name": "Hide related",
+  "author": "shazbot",
+  "version": "0.1",
+  "label": "Hide crossposts",
+  "login": false,
+  "recurs": true,
+  "desc": "Hide the crosspost section from the thread index/threads",
+  "entrypoint": "hide_related",
+  "page": "threads",
+  "namespace": "hide_related",
+  "fields": [
+    {
+      "key": "index",
+      "type": "checkbox",
+      "checkbox_label": "Hide on thread index"
+    },
+    {
+      "key": "thread",
+      "type": "checkbox",
+      "checkbox_label": "Hide inside threads"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves #428

Provides the option to hide related threads (crossposts) on the thread index, inside of threads, or both.