### PR TITLE
fix (user_instance_names): suppress whitespace

### DIFF
--- a/mods/mag_instance_names/mag_instance_names.user.js
+++ b/mods/mag_instance_names/mag_instance_names.user.js
@@ -15,7 +15,7 @@ function magInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
                     spanEl = "span"
                 }
                 const oldSpan = magazine.querySelector(spanEl)
-                oldSpan.classList.add("hidden-instance");
+                oldSpan.classList.add("mag-hidden-instance");
                 oldSpan.style.display = "none"
                 const newSpan = document.createElement("span")
                 newSpan.innerText = name + "@" + remote
@@ -32,9 +32,9 @@ function magInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
     }
 
     function hideRemotes () {
-        document.querySelectorAll('.hidden-instance').forEach((magazine) => {
+        document.querySelectorAll('.mag-hidden-instance').forEach((magazine) => {
             magazine.style.removeProperty("display");
-            magazine.classList.remove("hidden-instance");
+            magazine.classList.remove("mag-hidden-instance");
         });
         document.querySelectorAll('.mes-remote-instance').forEach((magazine) => {
             magazine.remove();

--- a/mods/user_instance_names/user_instance_names.user.js
+++ b/mods/user_instance_names/user_instance_names.user.js
@@ -4,7 +4,7 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
         const els = document.querySelectorAll(selector);
         els.forEach((el) => {
             if (el.getAttribute("data-instance") !== "true") {
-                if (el.classList.contains("hidden-instance")) return
+                if (el.classList.contains("user-hidden-instance")) return
                 const arr = el.getAttribute("title").split("@");
                 const name = arr[1];
                 const remote = arr[2];
@@ -12,7 +12,7 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
                     const clone = el.cloneNode(false);
                     clone.innerText = name + "@" + remote;
                     clone.setAttribute("data-instance", "true");
-                    el.classList.add("hidden-instance");
+                    el.classList.add("user-hidden-instance");
                     el.style.display = "none";
                     el.insertAdjacentElement("afterend", clone);
                 }
@@ -27,9 +27,9 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
                 el.remove();
             }
         });
-        document.querySelectorAll(".hidden-instance").forEach((el) => {
+        document.querySelectorAll(".user-hidden-instance").forEach((el) => {
             el.style.removeProperty("display");
-            el.classList.remove("hidden-instance");
+            el.classList.remove("user-hidden-instance");
         })
     }
 

--- a/mods/user_instance_names/user_instance_names.user.js
+++ b/mods/user_instance_names/user_instance_names.user.js
@@ -4,10 +4,17 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
         const els = document.querySelectorAll(selector);
         els.forEach((el) => {
             if (el.getAttribute("data-instance") !== "true") {
-                const userInstance = el.getAttribute("href").split("@")[2];
-                if (userInstance) {
-                    el.innerText = el.innerText + "@" + userInstance;
-                    el.setAttribute("data-instance", "true")
+                if (el.classList.contains("hidden-instance")) return
+                const arr = el.getAttribute("title").split("@");
+                const name = arr[1];
+                const remote = arr[2];
+                if (name) {
+                    const clone = el.cloneNode(false);
+                    clone.innerText = name + "@" + remote;
+                    clone.setAttribute("data-instance", "true");
+                    el.classList.add("hidden-instance");
+                    el.style.display = "none";
+                    el.insertAdjacentElement("afterend", clone);
                 }
             }
         });
@@ -17,10 +24,13 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
         const els = document.querySelectorAll(selector);
         els.forEach((el) => {
             if (el.getAttribute("data-instance") === "true") {
-                el.setAttribute("data-instance", "false");
-                el.innerText = el.innerText.split("@")[0]
+                el.remove();
             }
         });
+        document.querySelectorAll(".hidden-instance").forEach((el) => {
+            el.style.removeProperty("display");
+            el.classList.remove("hidden-instance");
+        })
     }
 
     function setSelector () {
@@ -43,11 +53,6 @@ function userInstanceEntry (toggle) { // eslint-disable-line no-unused-vars
     }
 
     const selector = setSelector();
-
-    if (toggle) {
-        showUserInstances(selector);
-    } else {
-        hideUserInstances(selector);
-        return
-    }
+    if (toggle) showUserInstances(selector);
+    if (!toggle) hideUserInstances(selector);
 }


### PR DESCRIPTION
Uses logic similar to the one in #446 to normalize usernames and suppress whitespace by using the link attributes instead of the innerText.