### PR TITLE
feat: generic loading dialog

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,7 +24,8 @@
         "getPageType": "readonly",
         "isLoggedIn": "readonly",
         "log": "readonly",
-        "Log": "readonly"
+        "Log": "readonly",
+        "makeLoader": "readonly"
     },
     "env": {
         "browser": true,

--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,8 @@
         "isLoggedIn": "readonly",
         "log": "readonly",
         "Log": "readonly",
-        "makeLoader": "readonly"
+        "makeLoader": "readonly",
+        "clearLoader": "readonly"
     },
     "env": {
         "browser": true,

--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -104,10 +104,10 @@ function makeLoader (id, text) {
     spinner.className = "hourglass";
     msg.appendChild(spinner);
     modal.appendChild(span);
-    const css-id = "mes-loader-css";
-    safeGM("removeStyle", css-id);
-    safeGM("addStyle", modalCSS, css-id);
-    log(`Added the sheet '${css-id}' to the document head`, Log.Log);
+    const cssID = "mes-loader-css";
+    safeGM("removeStyle", cssID);
+    safeGM("addStyle", modalCSS, cssID);
+    log(`Added the sheet '${cssID}' to the document head`, Log.Log);
     return modal_bg
 }
 

--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -24,6 +24,93 @@ function log (string, level) { // eslint-disable-line no-unused-vars
     }
 }
 
+//returns a generic loading prompt with spinner
+function makeLoader (id, text) {
+    const modalCSS = `
+    #${id}-filter-modal-bg {
+        position: fixed;
+        width: 100%;
+        height: 100%;
+        z-index: 90;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        left: 0;
+        top: 0;
+        background-color: rgba(0, 0, 0, 0.5) !important;
+    }
+
+    #${id}-filter-modal {
+        background-color: var(--kbin-section-bg);
+        width: 500px;
+        height: 100px;
+        display: grid;
+        justify-content: center;
+        align-items: center;
+        border: 1px solid black;
+    }
+    #${id}-filter-text {
+        color: var(--kbin-section-text-color);
+        margin: 20px
+    }
+    .hourglass,
+    .hourglass:after {
+      box-sizing: border-box;
+    }
+    .hourglass {
+      display: inline-flex;
+      position: relative;
+      width: 10px;
+      height: 10px;
+    }
+    .hourglass:after {
+      content: " ";
+      display: block;
+      border-radius: 50%;
+      width: 0;
+      height: 0;
+      margin: 8px;
+      box-sizing: border-box;
+      border: 10px solid currentColor;
+      border-color: currentColor transparent currentColor transparent;
+      animation: hourglass 1.2s infinite;
+    }
+    @keyframes hourglass {
+      0% {
+        transform: rotate(0);
+        animation-timing-function: cubic-bezier(0.55, 0.055, 0.675, 0.19);
+      }
+      50% {
+        transform: rotate(900deg);
+        animation-timing-function: cubic-bezier(0.215, 0.61, 0.355, 1);
+      }
+      100% {
+        transform: rotate(1800deg);
+      }
+    }
+
+    `;
+    const modal_bg = document.createElement("div");
+    const modal = document.createElement("div");
+    const span = document.createElement("span");
+    const msg = document.createElement("p");
+    modal_bg.id = `${id}-filter-modal-bg`;
+    modal.id = `${id}-filter-modal`;
+    msg.id = `${id}-filter-text`;
+    msg.innerText = `${text}`;
+    modal_bg.appendChild(modal);
+    span.appendChild(msg);
+    const spinner = document.createElement("div");
+    spinner.className = "hourglass";
+    msg.appendChild(spinner);
+    modal.appendChild(span);
+    const css-id = "mes-loader-css";
+    safeGM("removeStyle", css-id);
+    safeGM("addStyle", modalCSS, css-id);
+    log(`Added the sheet '${css-id}' to the document head`, Log.Log);
+    return modal_bg
+}
+
 //adds custom CSS to the document head by named ID
 function addCustomCSS (css, id) {
     const style = document.createElement('style');

--- a/helpers/safegm.user.js
+++ b/helpers/safegm.user.js
@@ -111,6 +111,12 @@ function makeLoader (id, text) {
     return modal_bg
 }
 
+//removes a loading dialog created with makeLoader()
+function clearLoader (id) {
+    document.querySelector(`${id}-filter-modal-bg`);
+    safeGM("removeStyle", "mes-loader-css");
+}
+
 //adds custom CSS to the document head by named ID
 function addCustomCSS (css, id) {
     const style = document.createElement('style');

--- a/mods/remove_ads/remove_ads.js
+++ b/mods/remove_ads/remove_ads.js
@@ -6,15 +6,6 @@ function filter (toggle, mutation) { // eslint-disable-line no-unused-vars
     const weighted = settings["weight"]
     const block = settings["block"]
 
-    //
-    //currently unused
-    //const votes = document.querySelectorAll('.vote')
-    //function filter (posts) {
-    //    return Array.from(posts).filter((el) =>
-    //        parseInt(el.querySelector('.vote__up button span').innerText) <= parseInt(el.querySelector('.vote__down button span').innerText)
-    //    )
-    //}
-
     const user_ids = []
     const user_links = []
     const checked = []
@@ -30,59 +21,14 @@ function filter (toggle, mutation) { // eslint-disable-line no-unused-vars
     if (url[3] !== "m") return
     if (url[5] === "t") return
 
-    const modalCSS = `
-    #kes-filter-modal-bg {
-        position: fixed;
-        width: 100%;
-        height: 100%;
-        z-index: 90;
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        left: 0;
-        top: 0;
-        background-color: rgba(0, 0, 0, 0.5) !important;
-    }
-
-    #kes-filter-modal {
-        background-color: var(--kbin-section-bg);
-        width: 500px;
-        height: 100px;
-        display: grid;
-        justify-content: center;
-        align-items: center;
-        border: 1px solid black;
-    }
-    #kes-filter-text {
-        color: var(--kbin-section-text-color);
-        margin: 20px
-    }
-
-    `;
-
-
-    function makeModal () {
-        const modal_bg = document.createElement('div')
-        const modal = document.createElement('div')
-        const text = document.createElement('p')
-        modal_bg.id = "kes-filter-modal-bg"
-        modal.id = "kes-filter-modal"
-        text.id = "kes-filter-text"
-        text.innerText = "KES: filtering spam, please wait..."
-        modal_bg.appendChild(modal)
-        modal.appendChild(text)
-        return modal_bg
-    }
     
     function apply () {
-        modal = makeModal()
-        document.body.appendChild(modal)
-        safeGM("removeStyle", "kes-filter-css")
-        safeGM("addStyle", modalCSS, "kes-filter-css")
+        modal = makeLoader("spam-modal", "KES: filtering spam, please wait...");
+        document.body.appendChild(modal);
         check();
     }
     function unapply () {
-        safeGM("removeStyle", "kes-filter-css")
+        safeGM("removeStyle", "mes-filter-css");
     }
 
     function filterDupes (array) {

--- a/mods/remove_ads/remove_ads.js
+++ b/mods/remove_ads/remove_ads.js
@@ -210,7 +210,7 @@ function filter (toggle, mutation) { // eslint-disable-line no-unused-vars
                 }
             }
         }
-        modal.remove()
+        clearLoader("spam-modal")
         localStorage.setItem("kes-banned-users", banned)
         localStorage.setItem("kes-softbanned-users", softbanned)
         localStorage.setItem("kes-checked-users", checked)

--- a/mods/remove_ads/remove_ads.js
+++ b/mods/remove_ads/remove_ads.js
@@ -13,7 +13,6 @@ function filter (toggle, mutation) { // eslint-disable-line no-unused-vars
     const softbanned = []
 
     let unique_users = {}
-    let modal
     let iteration
     
     const domain = window.location.hostname
@@ -23,7 +22,7 @@ function filter (toggle, mutation) { // eslint-disable-line no-unused-vars
 
     
     function apply () {
-        modal = makeLoader("spam-modal", "KES: filtering spam, please wait...");
+        const modal = makeLoader("spam-modal", "KES: filtering spam, please wait...");
         document.body.appendChild(modal);
         check();
     }
@@ -70,7 +69,7 @@ function filter (toggle, mutation) { // eslint-disable-line no-unused-vars
         //arrays are initialized empty on each DOM recursion
         for (let i = 0; i < unique_users.length; ++i) {
             if (iteration == 1) {
-                modal.remove();
+                clearLoader("spam-modal");
             }
             if (str_checked.split(',').includes(unique_users[i])) {
                 checked.push(unique_users[i])


### PR DESCRIPTION
This recycles the loading prompt used in the `remove_ads` mod into a more generic dialog.

The dialog creation function can be globally called via `makeLoader(id, text)`, where `id` corresponds to an element id to assign to the dialog, and `text` corresponds to some user-facing string to print while loading. All child elements of the dialog are prefixed with the id originally supplied as a parameter to this function.

The function returns a modal dialog that can be inserted into the tree somewhere. During creation, it also leverages `safeGM("addStyle")` to append a named stylesheet to the document head. The stylesheet is always named `mes-loader-css`, and a stylesheet by the same name is removed prior to insertion, ensuring that there can only be one such sheet active at any given time. This prevents multiple mods calling this function from inserting duplicate sheets.

The mod author thus only needs to call `makeLoader` with the requisite parameters and the mod is responsible for:

- Insertion of the node
- Showing/hiding the node

Finally, `clearLoader()` can be called with the original id passed to `makeLoader()`. This function is responsible for removing the dialog and clearing the associated stylesheet.

This dialog would chiefly be used by mods with some expected delay, such as `remove_ads`, `softblock`, `thread_checkmarks`, and `omni`. 