### PR TITLE
fix: do not trigger on HTML mutation

### DIFF
--- a/kes.user.js
+++ b/kes.user.js
@@ -1404,17 +1404,6 @@ function constructMenu (json, layoutArr, isNew) {
     function initmut (list) {
         const timestamp_json = { "login": false, "entrypoint": "timestamp" }
         for (const mutation of list) {
-            if (mutation.target.nodeName == "HTML") {
-                //implies that turbo mode reloaded the entire DOM tree
-                //the KES modal is itself running in the background,
-                //but when the entire DOM is reloaded in place the settings icon should be
-                //reinjected into the kbin navbar
-                injectSettingsButton(layoutArr, isNew)
-                for (let i = 0; i < json.length; ++i) {
-                    applySettings(json[i], mutation);
-                }
-                return
-            }
             //trigger when username popover dialog is spawned on hover
             //there can only be one popover spawned at a given time
             if (mutation.target.id === "popover") {

--- a/mods/omni/omni.user.js
+++ b/mods/omni/omni.user.js
@@ -441,7 +441,8 @@ function omniInit (toggle) { // eslint-disable-line no-unused-vars
     function keyTrap (e) {
         if (e.target.tagName === "INPUT") return
         if ((e.target.tagName === "TEXTAREA") && (e.target.id !== 'kes-omni-search')) return
-        document.querySelector('#kes-omni-keytrap')?.focus();
+        const kt = document.querySelector('#kes-omni-keytrap');
+        kt.focus();
     }
 
     const keytrap = document.querySelector('#kes-omni-keytrap-holder');
@@ -455,5 +456,9 @@ function omniInit (toggle) { // eslint-disable-line no-unused-vars
         safeGM("setValue",`omni-default-mags-${hostname}`, e);
         document.querySelector('#kes-omni-keytrap')?.remove();
         document.querySelector('.kes-omni-modal')?.remove;
+
+        const globalKeyInsert = document.querySelector('[data-controller="kbin notifications"]')
+            ?? document.querySelector('[data-controller="mbin notifications"]');
+        globalKeyInsert.removeEventListener('keydown',keyTrap);
     }
 }

--- a/mods/omni/omni.user.js
+++ b/mods/omni/omni.user.js
@@ -441,8 +441,7 @@ function omniInit (toggle) { // eslint-disable-line no-unused-vars
     function keyTrap (e) {
         if (e.target.tagName === "INPUT") return
         if ((e.target.tagName === "TEXTAREA") && (e.target.id !== 'kes-omni-search')) return
-        const kt = document.querySelector('#kes-omni-keytrap');
-        kt.focus();
+        document.querySelector('#kes-omni-keytrap')?.focus();
     }
 
     const keytrap = document.querySelector('#kes-omni-keytrap-holder');
@@ -456,9 +455,5 @@ function omniInit (toggle) { // eslint-disable-line no-unused-vars
         safeGM("setValue",`omni-default-mags-${hostname}`, e);
         document.querySelector('#kes-omni-keytrap')?.remove();
         document.querySelector('.kes-omni-modal')?.remove;
-
-        const globalKeyInsert = document.querySelector('[data-controller="kbin notifications"]')
-            ?? document.querySelector('[data-controller="mbin notifications"]');
-        globalKeyInsert.removeEventListener('keydown',keyTrap);
     }
 }


### PR DESCRIPTION
Resolves #465. 

The MES MutationObserver previously watched for change to the entire HTML tree, which was necessary because Kbin provided a feature called "Turbo Mode" that would fetch remote content and load it in-place by rewriting the entire DOM. This feature no longer exists on Mbin (link navigation works in a standard fashion).

On Chromium-based browsers, `focus()` events were triggering an HTML mutation that produced false positives, causing MES to try to step through functions again. 

This PR drops this part of the mutation check.